### PR TITLE
chore: remove duplicate classNames for button

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -20,8 +20,8 @@ const buttonVariants = cva(
       },
       size: {
         default: 'px-4 py-2 native:px-6 native:py-3.5',
-        sm: 'px-3 py-1 px-3 native:py-2',
-        lg: 'px-8 py-1.5 px-8 native:py-4',
+        sm: 'px-3 py-1 native:py-2',
+        lg: 'px-8 py-1.5 native:py-4',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
The button size variants had duplicate padding classNames which were giving eslint errors