### PR TITLE
feat(universal): add single text component w/context to replace other children text components

### DIFF
--- a/app/(main)/alert-dialog/alert-dialog-universal.tsx
+++ b/app/(main)/alert-dialog/alert-dialog-universal.tsx
@@ -3,9 +3,7 @@ import { View } from 'react-native';
 import {
   AlertDialog,
   AlertDialogAction,
-  AlertDialogActionText,
   AlertDialogCancel,
-  AlertDialogCancelText,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -13,7 +11,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '~/components/universal-ui/alert-dialog';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function AlertDialogUniversalScreen() {
   const [open, setOpen] = React.useState(false);
@@ -22,7 +21,7 @@ export default function AlertDialogUniversalScreen() {
       <AlertDialog open={open} onOpenChange={setOpen}>
         <AlertDialogTrigger asChild>
           <Button variant='outline'>
-            <ButtonText>Show Alert Dialog</ButtonText>
+            <Text>Show Alert Dialog</Text>
           </Button>
         </AlertDialogTrigger>
         <AlertDialogContent>
@@ -35,10 +34,10 @@ export default function AlertDialogUniversalScreen() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>
-              <AlertDialogCancelText>Cancel</AlertDialogCancelText>
+              <Text>Cancel</Text>
             </AlertDialogCancel>
             <AlertDialogAction>
-              <AlertDialogActionText>Continue</AlertDialogActionText>
+              <Text>Continue</Text>
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/(main)/avatar/avatar-universal.tsx
+++ b/app/(main)/avatar/avatar-universal.tsx
@@ -2,9 +2,9 @@ import { View } from 'react-native';
 import {
   Avatar,
   AvatarFallback,
-  AvatarFallbackText,
   AvatarImage,
 } from '~/components/universal-ui/avatar';
+import { Text } from '~/components/universal-ui/typography';
 
 const GITHUB_AVATAR_URI = 'https://github.com/mrzachnugent.png';
 
@@ -14,7 +14,7 @@ export default function AvatarPrimitiveScreen() {
       <Avatar alt="Zach Nugent's Avatar">
         <AvatarImage source={{ uri: GITHUB_AVATAR_URI }} />
         <AvatarFallback>
-          <AvatarFallbackText>ZN</AvatarFallbackText>
+          <Text>ZN</Text>
         </AvatarFallback>
       </Avatar>
     </View>

--- a/app/(main)/badge/badge-universal.tsx
+++ b/app/(main)/badge/badge-universal.tsx
@@ -1,20 +1,21 @@
 import { View } from 'react-native';
-import { Badge, BadgeText } from '~/components/universal-ui/badge';
+import { Badge } from '~/components/universal-ui/badge';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function BadgeUniversalScreen() {
   return (
     <View className='flex-1 justify-center items-center gap-5'>
       <Badge>
-        <BadgeText>Default</BadgeText>
+        <Text>Default</Text>
       </Badge>
       <Badge variant={'secondary'}>
-        <BadgeText>Secondary</BadgeText>
+        <Text>Secondary</Text>
       </Badge>
       <Badge variant={'destructive'}>
-        <BadgeText>Destructive</BadgeText>
+        <Text>Destructive</Text>
       </Badge>
       <Badge variant={'outline'}>
-        <BadgeText>Outline</BadgeText>
+        <Text>Outline</Text>
       </Badge>
     </View>
   );

--- a/app/(main)/button/button-universal.tsx
+++ b/app/(main)/button/button-universal.tsx
@@ -1,32 +1,33 @@
 import { View } from 'react-native';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function ButtonUniversalScreen() {
   return (
     <View className='flex-1 justify-center items-center gap-5'>
       <Button>
-        <ButtonText>Default</ButtonText>
+        <Text>Default</Text>
       </Button>
       <Button variant='destructive'>
-        <ButtonText>Destructive</ButtonText>
+        <Text>Destructive</Text>
       </Button>
       <Button variant='destructive' disabled>
-        <ButtonText>Destructive disabled</ButtonText>
+        <Text>Destructive disabled</Text>
       </Button>
       <Button variant='secondary'>
-        <ButtonText>Secondary</ButtonText>
+        <Text>Secondary</Text>
       </Button>
       <Button variant='outline' size='lg'>
-        <ButtonText>Outline lg</ButtonText>
+        <Text>Outline lg</Text>
       </Button>
       <Button variant='outline' size='sm'>
-        <ButtonText>Outline sm</ButtonText>
+        <Text>Outline sm</Text>
       </Button>
       <Button variant='ghost'>
-        <ButtonText>Ghost</ButtonText>
+        <Text>Ghost</Text>
       </Button>
       <Button variant='link' size='sm'>
-        <ButtonText>Link sm</ButtonText>
+        <Text>Link sm</Text>
       </Button>
     </View>
   );

--- a/app/(main)/card/card-universal.tsx
+++ b/app/(main)/card/card-universal.tsx
@@ -5,9 +5,9 @@ import {
   CardDescription,
   CardFooter,
   CardHeader,
-  CardText,
   CardTitle,
 } from '~/components/universal-ui/card';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function ButtonUniversalScreen() {
   return (
@@ -18,10 +18,10 @@ export default function ButtonUniversalScreen() {
           <CardDescription>Card Description</CardDescription>
         </CardHeader>
         <CardContent>
-          <CardText>Card Content</CardText>
+          <Text>Card Content</Text>
         </CardContent>
         <CardFooter>
-          <CardText>Card Footer</CardText>
+          <Text>Card Footer</Text>
         </CardFooter>
       </Card>
     </View>

--- a/app/(main)/context-menu/context-menu-universal.tsx
+++ b/app/(main)/context-menu/context-menu-universal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, Text, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
@@ -7,7 +7,6 @@ import {
   ContextMenuCheckboxItem,
   ContextMenuContent,
   ContextMenuItem,
-  ContextMenuItemText,
   ContextMenuLabel,
   ContextMenuRadioGroup,
   ContextMenuRadioItem,
@@ -16,9 +15,9 @@ import {
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
-  ContextMenuSubTriggerText,
   ContextMenuTrigger,
 } from '~/components/universal-ui/context-menu';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function ContextPrimitiveScreen() {
   const [open, setOpen] = React.useState(false);
@@ -58,39 +57,35 @@ export default function ContextPrimitiveScreen() {
             className='w-64 native:w-72'
           >
             <ContextMenuItem inset>
-              <ContextMenuItemText>Back</ContextMenuItemText>
+              <Text>Back</Text>
               <ContextMenuShortcut>⌘[</ContextMenuShortcut>
             </ContextMenuItem>
             <ContextMenuItem inset disabled>
-              <ContextMenuItemText>Forward</ContextMenuItemText>
+              <Text>Forward</Text>
               <ContextMenuShortcut>⌘]</ContextMenuShortcut>
             </ContextMenuItem>
             <ContextMenuItem inset>
-              <ContextMenuItemText>Reload</ContextMenuItemText>
+              <Text>Reload</Text>
               <ContextMenuShortcut>⌘R</ContextMenuShortcut>
             </ContextMenuItem>
 
             <ContextMenuSub open={openSub} onOpenChange={setOpenSub}>
               <ContextMenuSubTrigger inset>
-                <ContextMenuSubTriggerText>
-                  More Tools
-                </ContextMenuSubTriggerText>
+                <Text>More Tools</Text>
               </ContextMenuSubTrigger>
               <ContextMenuSubContent className='web:w-48 native:mt-1'>
                 <Animated.View entering={FadeIn.duration(200)}>
                   <ContextMenuItem>
-                    <ContextMenuItemText>Save Page As...</ContextMenuItemText>
+                    <Text>Save Page As...</Text>
                     <ContextMenuShortcut>⇧⌘S</ContextMenuShortcut>
                   </ContextMenuItem>
                   <ContextMenuItem>
-                    <ContextMenuItemText>
-                      Create Shortcut...
-                    </ContextMenuItemText>
+                    <Text>Create Shortcut...</Text>
                   </ContextMenuItem>
 
                   <ContextMenuSeparator />
                   <ContextMenuItem>
-                    <ContextMenuItemText>Developer Tools</ContextMenuItemText>
+                    <Text>Developer Tools</Text>
                   </ContextMenuItem>
                 </Animated.View>
               </ContextMenuSubContent>
@@ -102,7 +97,7 @@ export default function ContextPrimitiveScreen() {
               onCheckedChange={setCheckboxValue}
               closeOnPress={false}
             >
-              <ContextMenuItemText>Show Bookmarks Bar</ContextMenuItemText>
+              <Text>Show Bookmarks Bar</Text>
               <ContextMenuShortcut>⌘⇧B</ContextMenuShortcut>
             </ContextMenuCheckboxItem>
             <ContextMenuCheckboxItem
@@ -110,22 +105,20 @@ export default function ContextPrimitiveScreen() {
               onCheckedChange={setSubCheckboxValue}
               closeOnPress={false}
             >
-              <ContextMenuItemText>Show Full URLs</ContextMenuItemText>
+              <Text>Show Full URLs</Text>
             </ContextMenuCheckboxItem>
             <ContextMenuSeparator />
             <ContextMenuRadioGroup
               value={radioValue}
               onValueChange={setRadioValue}
             >
-              <ContextMenuLabel inset>
-                <ContextMenuItemText>People</ContextMenuItemText>
-              </ContextMenuLabel>
+              <ContextMenuLabel inset>People</ContextMenuLabel>
               <ContextMenuSeparator />
               <ContextMenuRadioItem value='pedro' closeOnPress={false}>
-                <ContextMenuItemText>Elmer Fudd</ContextMenuItemText>
+                <Text>Elmer Fudd</Text>
               </ContextMenuRadioItem>
               <ContextMenuRadioItem value='colm' closeOnPress={false}>
-                <ContextMenuItemText>Foghorn Leghorn</ContextMenuItemText>
+                <Text>Foghorn Leghorn</Text>
               </ContextMenuRadioItem>
             </ContextMenuRadioGroup>
           </ContextMenuContent>

--- a/app/(main)/dialog/dialog-universal.tsx
+++ b/app/(main)/dialog/dialog-universal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ScrollView } from 'react-native';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
+import { Text } from '~/components/universal-ui/typography';
 import {
   Dialog,
   DialogClose,
@@ -19,7 +20,7 @@ export default function DialogUniversalScreen() {
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>
           <Button variant='outline'>
-            <ButtonText>Edit Profile</ButtonText>
+            <Text>Edit Profile</Text>
           </Button>
         </DialogTrigger>
         <DialogContent className='sm:max-w-[425px]'>
@@ -33,7 +34,7 @@ export default function DialogUniversalScreen() {
           <DialogFooter>
             <DialogClose asChild>
               <Button>
-                <ButtonText>OK</ButtonText>
+                <Text>OK</Text>
               </Button>
             </DialogClose>
           </DialogFooter>

--- a/app/(main)/dropdown-menu/dropdown-menu-universal.tsx
+++ b/app/(main)/dropdown-menu/dropdown-menu-universal.tsx
@@ -14,13 +14,13 @@ import React from 'react';
 import { View } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
+import { Text } from '~/components/universal-ui/typography';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuItemText,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
@@ -54,7 +54,7 @@ export default function DropdownMenuUniversalScreen() {
       >
         <DropdownMenuTrigger asChild>
           <Button variant='outline'>
-            <ButtonText>Open</ButtonText>
+            <Text>Open</Text>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -66,54 +66,54 @@ export default function DropdownMenuUniversalScreen() {
           <DropdownMenuGroup>
             <DropdownMenuItem>
               <Users className='text-foreground' size={14} />
-              <DropdownMenuItemText>Team</DropdownMenuItemText>
+              <Text>Team</Text>
             </DropdownMenuItem>
             <DropdownMenuSub open={openSub} onOpenChange={setOpenSub}>
               <DropdownMenuSubTrigger>
                 <UserPlus className='text-foreground' size={14} />
-                <DropdownMenuItemText>Invite users</DropdownMenuItemText>
+                <Text>Invite users</Text>
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 <Animated.View entering={FadeIn.duration(200)}>
                   <DropdownMenuItem>
                     <Mail className='text-foreground' size={14} />
-                    <DropdownMenuItemText>Email</DropdownMenuItemText>
+                    <Text>Email</Text>
                   </DropdownMenuItem>
                   <DropdownMenuItem>
                     <MessageSquare className='text-foreground' size={14} />
-                    <DropdownMenuItemText>Message</DropdownMenuItemText>
+                    <Text>Message</Text>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem>
                     <PlusCircle className='text-foreground' size={14} />
-                    <DropdownMenuItemText>More...</DropdownMenuItemText>
+                    <Text>More...</Text>
                   </DropdownMenuItem>
                 </Animated.View>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
             <DropdownMenuItem>
               <Plus className='text-foreground' size={14} />
-              <DropdownMenuItemText>New Team</DropdownMenuItemText>
+              <Text>New Team</Text>
               <DropdownMenuShortcut>⌘+T</DropdownMenuShortcut>
             </DropdownMenuItem>
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuItem>
             <Github className='text-foreground' size={14} />
-            <DropdownMenuItemText>GitHub</DropdownMenuItemText>
+            <Text>GitHub</Text>
           </DropdownMenuItem>
           <DropdownMenuItem>
             <LifeBuoy className='text-foreground' size={14} />
-            <DropdownMenuItemText>Support</DropdownMenuItemText>
+            <Text>Support</Text>
           </DropdownMenuItem>
           <DropdownMenuItem disabled>
             <Cloud className='text-foreground' size={14} />
-            <DropdownMenuItemText>API</DropdownMenuItemText>
+            <Text>API</Text>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem>
             <LogOut className='text-foreground' size={14} />
-            <DropdownMenuItemText>Log out</DropdownMenuItemText>
+            <Text>Log out</Text>
             <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/app/(main)/hover-card/hover-card-universal.tsx
+++ b/app/(main)/hover-card/hover-card-universal.tsx
@@ -7,13 +7,13 @@ import {
   AvatarFallback,
   AvatarImage,
 } from '~/components/universal-ui/avatar';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
 import {
   HoverCard,
   HoverCardContent,
-  HoverCardContentText,
   HoverCardTrigger,
 } from '~/components/universal-ui/hover-card';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function HoverCardUniversalScreen() {
   const [open, setOpen] = React.useState(false);
@@ -30,7 +30,7 @@ export default function HoverCardUniversalScreen() {
         <HoverCard open={open} onOpenChange={setOpen}>
           <HoverCardTrigger asChild>
             <Button variant='link' size='lg'>
-              <ButtonText>@nextjs</ButtonText>
+              <Text>@nextjs</Text>
             </Button>
           </HoverCardTrigger>
           <HoverCardContent insets={contentInsets} className='w-80 native:w-96'>
@@ -42,20 +42,20 @@ export default function HoverCardUniversalScreen() {
                 <AvatarFallback>VC</AvatarFallback>
               </Avatar>
               <View className='gap-1 flex-1'>
-                <HoverCardContentText className='text-sm native:text-base font-semibold'>
+                <Text className='text-sm native:text-base font-semibold'>
                   @nextjs
-                </HoverCardContentText>
-                <HoverCardContentText className='text-sm native:text-base'>
+                </Text>
+                <Text className='text-sm native:text-base'>
                   The React Framework – created and maintained by @vercel.
-                </HoverCardContentText>
+                </Text>
                 <View className='flex flex-row items-center pt-2 gap-2'>
                   <CalendarDays
                     size={14}
                     className='text-foreground opacity-70'
                   />
-                  <HoverCardContentText className='text-xs native:text-sm text-muted-foreground'>
+                  <Text className='text-xs native:text-sm text-muted-foreground'>
                     Joined December 2021
-                  </HoverCardContentText>
+                  </Text>
                 </View>
               </View>
             </View>

--- a/app/(main)/menubar/menubar-universal.tsx
+++ b/app/(main)/menubar/menubar-universal.tsx
@@ -9,7 +9,6 @@ import {
   MenubarCheckboxItem,
   MenubarContent,
   MenubarItem,
-  MenubarItemText,
   MenubarMenu,
   MenubarRadioGroup,
   MenubarRadioItem,
@@ -20,6 +19,7 @@ import {
   MenubarSubTrigger,
   MenubarTrigger,
 } from '~/components/universal-ui/menubar';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function MenubarPrimitiveScreen() {
   const insets = useSafeAreaInsets();
@@ -78,97 +78,97 @@ export default function MenubarPrimitiveScreen() {
       <Menubar value={value} onValueChange={onValueChange}>
         <MenubarMenu value='file'>
           <MenubarTrigger onPress={closeSubs}>
-            <MenubarItemText>File</MenubarItemText>
+            <Text>File</Text>
           </MenubarTrigger>
           <MenubarContent insets={contentInsets}>
             <MenubarItem>
-              <MenubarItemText>New Tab</MenubarItemText>
+              <Text>New Tab</Text>
               <MenubarShortcut>⌘T</MenubarShortcut>
             </MenubarItem>
             <MenubarItem>
-              <MenubarItemText>New Window</MenubarItemText>
+              <Text>New Window</Text>
               <MenubarShortcut>⌘N</MenubarShortcut>
             </MenubarItem>
             <MenubarItem disabled>
-              <MenubarItemText>New Incognito Window</MenubarItemText>
+              <Text>New Incognito Window</Text>
             </MenubarItem>
             <MenubarSeparator />
             <MenubarSub open={isSubOpen} onOpenChange={setIsSubOpen}>
               <MenubarSubTrigger>
-                <MenubarItemText>Share</MenubarItemText>
+                <Text>Share</Text>
               </MenubarSubTrigger>
               <MenubarSubContent>
                 <Animated.View entering={FadeIn.duration(200)}>
                   <MenubarItem>
-                    <MenubarItemText>Email link</MenubarItemText>
+                    <Text>Email link</Text>
                   </MenubarItem>
                   <MenubarItem>
-                    <MenubarItemText>Messages</MenubarItemText>
+                    <Text>Messages</Text>
                   </MenubarItem>
                   <MenubarItem>
-                    <MenubarItemText>Notes</MenubarItemText>
+                    <Text>Notes</Text>
                   </MenubarItem>
                 </Animated.View>
               </MenubarSubContent>
             </MenubarSub>
             <MenubarSeparator />
             <MenubarItem>
-              <MenubarItemText>Print...</MenubarItemText>
+              <Text>Print...</Text>
               <MenubarShortcut>⌘P</MenubarShortcut>
             </MenubarItem>
           </MenubarContent>
         </MenubarMenu>
         <MenubarMenu value='edit'>
           <MenubarTrigger onPress={closeSubs}>
-            <MenubarItemText>Edit</MenubarItemText>
+            <Text>Edit</Text>
           </MenubarTrigger>
           <MenubarContent insets={contentInsets} className='native:w-48'>
             <MenubarItem>
-              <MenubarItemText>Undo</MenubarItemText>
+              <Text>Undo</Text>
               <MenubarShortcut>⌘Z</MenubarShortcut>
             </MenubarItem>
             <MenubarItem>
-              <MenubarItemText>Redo</MenubarItemText>
+              <Text>Redo</Text>
               <MenubarShortcut>⇧⌘Z</MenubarShortcut>
             </MenubarItem>
             <MenubarSeparator />
             <MenubarSub open={isSubOpen2} onOpenChange={setIsSubOpen2}>
               <MenubarSubTrigger>
-                <MenubarItemText>Find</MenubarItemText>
+                <Text>Find</Text>
               </MenubarSubTrigger>
               <MenubarSubContent>
                 <Animated.View entering={FadeIn.duration(200)}>
                   <MenubarItem>
-                    <MenubarItemText>Search the web</MenubarItemText>
+                    <Text>Search the web</Text>
                   </MenubarItem>
                   <MenubarSeparator />
                   <MenubarItem>
-                    <MenubarItemText>Find...</MenubarItemText>
+                    <Text>Find...</Text>
                   </MenubarItem>
                   <MenubarItem>
-                    <MenubarItemText>Find Next</MenubarItemText>
+                    <Text>Find Next</Text>
                   </MenubarItem>
                   <MenubarItem>
-                    <MenubarItemText>Find Previous</MenubarItemText>
+                    <Text>Find Previous</Text>
                   </MenubarItem>
                 </Animated.View>
               </MenubarSubContent>
             </MenubarSub>
             <MenubarSeparator />
             <MenubarItem>
-              <MenubarItemText>Cut</MenubarItemText>
+              <Text>Cut</Text>
             </MenubarItem>
             <MenubarItem>
-              <MenubarItemText>Copy</MenubarItemText>
+              <Text>Copy</Text>
             </MenubarItem>
             <MenubarItem>
-              <MenubarItemText>Paste</MenubarItemText>
+              <Text>Paste</Text>
             </MenubarItem>
           </MenubarContent>
         </MenubarMenu>
         <MenubarMenu value='view'>
           <MenubarTrigger onPress={closeSubs}>
-            <MenubarItemText>View</MenubarItemText>
+            <Text>View</Text>
           </MenubarTrigger>
           <MenubarContent insets={contentInsets}>
             <MenubarCheckboxItem
@@ -176,57 +176,57 @@ export default function MenubarPrimitiveScreen() {
               onCheckedChange={setIsChecked}
               closeOnPress={false}
             >
-              <MenubarItemText>Always Show Bookmarks Bar</MenubarItemText>
+              <Text>Always Show Bookmarks Bar</Text>
             </MenubarCheckboxItem>
             <MenubarCheckboxItem
               checked={isChecked2}
               onCheckedChange={setIsChecked2}
               closeOnPress={false}
             >
-              <MenubarItemText>Always Show Full URLs</MenubarItemText>
+              <Text>Always Show Full URLs</Text>
             </MenubarCheckboxItem>
             <MenubarSeparator />
             <MenubarItem inset>
-              <MenubarItemText>Reload</MenubarItemText>
+              <Text>Reload</Text>
               <MenubarShortcut>⌘R</MenubarShortcut>
             </MenubarItem>
             <MenubarItem disabled inset>
-              <MenubarItemText>Force Reload</MenubarItemText>
+              <Text>Force Reload</Text>
               <MenubarShortcut>⇧⌘R</MenubarShortcut>
             </MenubarItem>
             <MenubarSeparator />
             <MenubarItem inset>
-              <MenubarItemText>Toggle Fullscreen</MenubarItemText>
+              <Text>Toggle Fullscreen</Text>
             </MenubarItem>
             <MenubarSeparator />
             <MenubarItem inset>
-              <MenubarItemText>Hide Sidebar</MenubarItemText>
+              <Text>Hide Sidebar</Text>
             </MenubarItem>
           </MenubarContent>
         </MenubarMenu>
         <MenubarMenu value='profile'>
           <MenubarTrigger onPress={closeSubs}>
-            <MenubarItemText>Profiles</MenubarItemText>
+            <Text>Profiles</Text>
           </MenubarTrigger>
           <MenubarContent insets={contentInsets}>
             <MenubarRadioGroup value={radio} onValueChange={setRadio}>
               <MenubarRadioItem closeOnPress={false} value='andy'>
-                <MenubarItemText>Andy</MenubarItemText>
+                <Text>Andy</Text>
               </MenubarRadioItem>
               <MenubarRadioItem closeOnPress={false} value='michael'>
-                <MenubarItemText>Michael</MenubarItemText>
+                <Text>Michael</Text>
               </MenubarRadioItem>
               <MenubarRadioItem closeOnPress={false} value='creed'>
-                <MenubarItemText>Creed</MenubarItemText>
+                <Text>Creed</Text>
               </MenubarRadioItem>
             </MenubarRadioGroup>
             <MenubarSeparator />
             <MenubarItem inset>
-              <MenubarItemText>Edit...</MenubarItemText>
+              <Text>Edit...</Text>
             </MenubarItem>
             <MenubarSeparator />
             <MenubarItem inset>
-              <MenubarItemText>Add Profile...</MenubarItemText>
+              <Text>Add Profile...</Text>
             </MenubarItem>
           </MenubarContent>
         </MenubarMenu>

--- a/app/(main)/navigation-menu/navigation-menu-universal.tsx
+++ b/app/(main)/navigation-menu/navigation-menu-universal.tsx
@@ -2,7 +2,7 @@ import { useDrawerStatus } from '@react-navigation/drawer';
 import { useNavigation } from 'expo-router';
 import { Sparkles } from 'lucide-react-native';
 import React from 'react';
-import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   NavigationMenu,
@@ -15,6 +15,7 @@ import {
 } from '~/components/universal-ui/navigation-menu';
 import { TextRef } from '~/lib/rn-primitives/types';
 import { cn } from '~/lib/utils';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function MenubarPrimitiveScreen() {
   const insets = useSafeAreaInsets();
@@ -60,7 +61,7 @@ export default function MenubarPrimitiveScreen() {
         <NavigationMenuList>
           <NavigationMenuItem value='getting-started'>
             <NavigationMenuTrigger>
-              <Text className='text-foreground'>Getting started</Text>
+              <Text>Getting started</Text>
             </NavigationMenuTrigger>
             <NavigationMenuContent insets={contentInsets}>
               <View
@@ -71,7 +72,7 @@ export default function MenubarPrimitiveScreen() {
                   <NavigationMenuLink asChild>
                     <View className='flex select-none flex-col justify-end rounded-md web:bg-gradient-to-b web:from-muted/50 web:to-muted native:border native:border-border p-6 web:no-underline web:outline-none focus:shadow-md'>
                       <Sparkles size={16} className='text-foreground' />
-                      <Text className='mb-2 mt-4 text-lg native:text-2xl font-medium text-foreground'>
+                      <Text className='mb-2 mt-4 text-lg native:text-2xl font-medium'>
                         react-native-reusables
                       </Text>
                       <Text className='text-sm native:text-base leading-tight text-muted-foreground'>
@@ -82,20 +83,18 @@ export default function MenubarPrimitiveScreen() {
                   </NavigationMenuLink>
                 </View>
                 <ListItem href='/docs' title='Introduction'>
-                  <Text className='text-foreground'>
+                  <Text>
                     Re-usable components built using Radix UI on the web and
                     Tailwind CSS.
                   </Text>
                 </ListItem>
                 <ListItem href='/docs/installation' title='Installation'>
-                  <Text className='text-foreground'>
+                  <Text>
                     How to install dependencies and structure your app.
                   </Text>
                 </ListItem>
                 <ListItem href='/docs/primitives/typography' title='Typography'>
-                  <Text className='text-foreground'>
-                    Styles for headings, paragraphs, lists...etc
-                  </Text>
+                  <Text>Styles for headings, paragraphs, lists...etc</Text>
                 </ListItem>
               </View>
             </NavigationMenuContent>
@@ -126,7 +125,7 @@ export default function MenubarPrimitiveScreen() {
               onPress={closeAll}
               className={navigationMenuTriggerStyle()}
             >
-              <Text className='text-foreground '>Documentation</Text>
+              <Text>Documentation</Text>
             </NavigationMenuLink>
           </NavigationMenuItem>
         </NavigationMenuList>

--- a/app/(main)/popover/popover-universal.tsx
+++ b/app/(main)/popover/popover-universal.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { Platform, Text, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
 import { Input } from '~/components/universal-ui/input';
 import { Label, LabelText } from '~/components/universal-ui/label';
 import {
   Popover,
   PopoverContent,
-  PopoverText,
   PopoverTrigger,
 } from '~/components/universal-ui/popover';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function PopoverUniversalScreen() {
   const [open, setOpen] = React.useState(false);
@@ -26,7 +26,7 @@ export default function PopoverUniversalScreen() {
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button variant='outline'>
-            <ButtonText>Open popover</ButtonText>
+            <Text>Open popover</Text>
           </Button>
         </PopoverTrigger>
         <PopoverContent
@@ -36,9 +36,9 @@ export default function PopoverUniversalScreen() {
         >
           <View className='web:grid gap-4'>
             <View className='space-y-2'>
-              <PopoverText className='font-medium leading-none native:text-xl'>
+              <Text className='font-medium leading-none native:text-xl'>
                 Dimensions
-              </PopoverText>
+              </Text>
               <Text className='text-sm text-muted-foreground'>
                 Set the dimensions for the layer.
               </Text>

--- a/app/(main)/progress/progress-universal.tsx
+++ b/app/(main)/progress/progress-universal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
 import { Progress } from '~/components/universal-ui/progress';
+import { Text } from '~/components/universal-ui/typography';
 
 export default function ProgressUniversalScreen() {
   const [progress, setProgress] = React.useState(13);
@@ -15,7 +16,7 @@ export default function ProgressUniversalScreen() {
       <View className='w-full gap-8 items-center'>
         <Progress value={progress} className='web:w-[60%]' />
         <Button variant='ghost' onPress={onPress}>
-          <ButtonText>Randomize</ButtonText>
+          <Text>Randomize</Text>
         </Button>
       </View>
     </View>

--- a/app/(main)/tabs/tabs-universal.tsx
+++ b/app/(main)/tabs/tabs-universal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
+import { Text } from '~/components/universal-ui/typography';
 import {
   Card,
   CardContent,
@@ -16,7 +17,6 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
-  TabsTriggerText,
 } from '~/components/universal-ui/tabs';
 
 export default function TabsPrimitiveScreen() {
@@ -30,10 +30,10 @@ export default function TabsPrimitiveScreen() {
       >
         <TabsList className='flex-row w-full'>
           <TabsTrigger value='account' className='flex-1'>
-            <TabsTriggerText>Account</TabsTriggerText>
+            <Text>Account</Text>
           </TabsTrigger>
           <TabsTrigger value='password' className='flex-1'>
-            <TabsTriggerText>Password</TabsTriggerText>
+            <Text>Password</Text>
           </TabsTrigger>
         </TabsList>
         <TabsContent value='account'>
@@ -63,7 +63,7 @@ export default function TabsPrimitiveScreen() {
             </CardContent>
             <CardFooter>
               <Button>
-                <ButtonText>Save changes</ButtonText>
+                <Text>Save changes</Text>
               </Button>
             </CardFooter>
           </Card>
@@ -100,7 +100,7 @@ export default function TabsPrimitiveScreen() {
             </CardContent>
             <CardFooter>
               <Button>
-                <ButtonText>Save password</ButtonText>
+                <Text>Save password</Text>
               </Button>
             </CardFooter>
           </Card>

--- a/app/(main)/tooltip/tooltip-universal.tsx
+++ b/app/(main)/tooltip/tooltip-universal.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Platform, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Button, ButtonText } from '~/components/universal-ui/button';
+import { Button } from '~/components/universal-ui/button';
+import { Text } from '~/components/universal-ui/typography';
 import {
   Tooltip,
   TooltipContent,
-  TooltipText,
   TooltipTrigger,
 } from '~/components/universal-ui/tooltip';
 
@@ -23,13 +23,11 @@ export default function TooltipUniversalScreen() {
       <Tooltip open={open} onOpenChange={setOpen} delayDuration={150}>
         <TooltipTrigger asChild>
           <Button variant='outline'>
-            <ButtonText>
-              {Platform.OS === 'web' ? 'Hover me' : 'Press me'}
-            </ButtonText>
+            <Text>{Platform.OS === 'web' ? 'Hover me' : 'Press me'}</Text>
           </Button>
         </TooltipTrigger>
         <TooltipContent insets={contentInsets}>
-          <TooltipText className='native:text-lg'>Add to library</TooltipText>
+          <Text className='native:text-lg'>Add to library</Text>
         </TooltipContent>
       </Tooltip>
     </View>

--- a/components/universal-ui/alert-dialog.tsx
+++ b/components/universal-ui/alert-dialog.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import * as AlertDialogPrimitive from '~/lib/rn-primitives/alert-dialog';
-
-import { Text, View, StyleSheet, Platform } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import {
-  ButtonText,
   buttonTextVariants,
   buttonVariants,
 } from '~/components/universal-ui/button';
+import * as AlertDialogPrimitive from '~/lib/rn-primitives/alert-dialog';
 import { cn } from '~/lib/utils';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { TextClassContext } from '~/components/universal-ui/typography';
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -151,56 +150,36 @@ const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action
-    ref={ref}
-    className={cn(buttonVariants(), className)}
-    {...props}
-  />
+  <TextClassContext.Provider value={buttonTextVariants({ className })}>
+    <AlertDialogPrimitive.Action
+      ref={ref}
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  </TextClassContext.Provider>
 ));
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
-
-const AlertDialogActionText = React.forwardRef<
-  React.ElementRef<typeof ButtonText>,
-  React.ComponentPropsWithoutRef<typeof ButtonText>
->(({ className, ...props }, ref) => (
-  <Text
-    ref={ref}
-    className={cn(buttonTextVariants({ className }))}
-    {...props}
-  />
-));
-AlertDialogActionText.displayName = 'AlertDialogActionText';
 
 const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel
-    ref={ref}
-    className={cn(buttonVariants({ variant: 'outline', className }))}
-    {...props}
-  />
+  <TextClassContext.Provider
+    value={buttonTextVariants({ className, variant: 'outline' })}
+  >
+    <AlertDialogPrimitive.Cancel
+      ref={ref}
+      className={cn(buttonVariants({ variant: 'outline', className }))}
+      {...props}
+    />
+  </TextClassContext.Provider>
 ));
 AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
-
-const AlertDialogCancelText = React.forwardRef<
-  React.ElementRef<typeof ButtonText>,
-  React.ComponentPropsWithoutRef<typeof ButtonText>
->(({ className, ...props }, ref) => (
-  <Text
-    ref={ref}
-    className={cn(buttonTextVariants({ className, variant: 'outline' }))}
-    {...props}
-  />
-));
-AlertDialogCancelText.displayName = 'AlertDialogCancelText';
 
 export {
   AlertDialog,
   AlertDialogAction,
-  AlertDialogActionText,
   AlertDialogCancel,
-  AlertDialogCancelText,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,

--- a/components/universal-ui/avatar.tsx
+++ b/components/universal-ui/avatar.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import * as AvatarPrimitive from '~/lib/rn-primitives/avatar';
-import * as Slot from '~/lib/rn-primitives/slot';
-import { SlottableTextProps, TextRef } from '~/lib/rn-primitives/types';
 
-import { Text } from 'react-native';
 import { cn } from '~/lib/utils';
 
 const Avatar = React.forwardRef<
@@ -48,20 +45,4 @@ const AvatarFallback = React.forwardRef<
 ));
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
-const AvatarFallbackText = React.forwardRef<TextRef, SlottableTextProps>(
-  ({ asChild, className, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
-    return (
-      <Component
-        ref={ref}
-        className={cn('text-foreground text-base', className)}
-        {...props}
-      >
-        ZN
-      </Component>
-    );
-  }
-);
-AvatarFallbackText.displayName = 'AvatarFallbackText';
-
-export { Avatar, AvatarImage, AvatarFallback, AvatarFallbackText };
+export { Avatar, AvatarFallback, AvatarImage };

--- a/components/universal-ui/badge.tsx
+++ b/components/universal-ui/badge.tsx
@@ -1,13 +1,10 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
+import { View } from 'react-native';
 import * as Slot from '~/lib/rn-primitives/slot';
-
-import { Text, View } from 'react-native';
-import type {
-  SlottableTextProps,
-  SlottableViewProps,
-} from '~/lib/rn-primitives/types';
+import type { SlottableViewProps } from '~/lib/rn-primitives/types';
 import { cn } from '~/lib/utils';
+import { TextClassContext } from '~/components/universal-ui/typography';
 
 const badgeVariants = cva(
   'web:inline-flex items-center rounded-full border border-border px-2.5 py-0.5 web:transition-colors web:focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
@@ -45,42 +42,17 @@ const badgeTextVariants = cva('text-xs font-semibold ', {
 
 type BadgeProps = SlottableViewProps & VariantProps<typeof badgeVariants>;
 
-const BadgeContext = React.createContext<VariantProps<
-  typeof badgeVariants
-> | null>(null);
-
 function Badge({ className, variant, asChild, ...props }: BadgeProps) {
   const Component = asChild ? Slot.View : View;
   return (
-    <BadgeContext.Provider value={{ variant }}>
+    <TextClassContext.Provider value={badgeTextVariants({ variant })}>
       <Component
         className={cn(badgeVariants({ variant }), className)}
         {...props}
       />
-    </BadgeContext.Provider>
+    </TextClassContext.Provider>
   );
 }
 
-function useBadgeContext() {
-  const context = React.useContext(BadgeContext);
-  if (!context) {
-    throw new Error(
-      'Badge compound components cannot be rendered outside the Badge component'
-    );
-  }
-  return context;
-}
-
-function BadgeText({ className, asChild, ...props }: SlottableTextProps) {
-  const { variant } = useBadgeContext();
-  const Component = asChild ? Slot.Text : Text;
-  return (
-    <Component
-      className={cn(badgeTextVariants({ variant }), className)}
-      {...props}
-    />
-  );
-}
-
-export { Badge, BadgeText, badgeTextVariants, badgeVariants };
+export { Badge, badgeTextVariants, badgeVariants };
 export type { BadgeProps };

--- a/components/universal-ui/button.tsx
+++ b/components/universal-ui/button.tsx
@@ -1,15 +1,13 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
+import { Pressable } from 'react-native';
 import * as Slot from '~/lib/rn-primitives/slot';
-
-import { Pressable, Text } from 'react-native';
 import type {
   PressableRef,
   SlottablePressableProps,
-  SlottableTextProps,
-  TextRef,
 } from '~/lib/rn-primitives/types';
 import { cn } from '~/lib/utils';
+import { TextClassContext } from '~/components/universal-ui/typography';
 
 const buttonVariants = cva(
   'group flex items-center justify-center rounded-md ring-offset-background web:transition-colors web:focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
@@ -69,19 +67,15 @@ const buttonTextVariants = cva(
 type ButtonProps = SlottablePressableProps &
   VariantProps<typeof buttonVariants>;
 
-const ButtonContext = React.createContext<
-  | (VariantProps<typeof buttonVariants> & {
-      disabled: boolean | null | undefined;
-    })
-  | null
->(null);
-
 const Button = React.forwardRef<PressableRef, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Component = asChild ? Slot.Pressable : Pressable;
     return (
-      <ButtonContext.Provider
-        value={{ variant, size, disabled: props.disabled }}
+      <TextClassContext.Provider
+        value={cn(
+          props.disabled && 'web:pointer-events-none',
+          buttonTextVariants({ variant, size })
+        )}
       >
         <Component
           className={cn(
@@ -92,41 +86,11 @@ const Button = React.forwardRef<PressableRef, ButtonProps>(
           role='button'
           {...props}
         />
-      </ButtonContext.Provider>
+      </TextClassContext.Provider>
     );
   }
 );
 Button.displayName = 'Button';
 
-function useButtonContext() {
-  const context = React.useContext(ButtonContext);
-  if (context === null) {
-    throw new Error(
-      'Button compound components cannot be rendered outside the Button component'
-    );
-  }
-  return context;
-}
-
-type ButtonTextProps = SlottableTextProps;
-
-const ButtonText = React.forwardRef<TextRef, ButtonTextProps>(
-  ({ className, asChild = false, ...props }, ref) => {
-    const { size, variant, disabled } = useButtonContext();
-    const Component = asChild ? Slot.Text : Text;
-    return (
-      <Component
-        className={cn(
-          disabled && 'web:pointer-events-none',
-          buttonTextVariants({ variant, size, className })
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-ButtonText.displayName = 'ButtonText';
-
-export { Button, ButtonText, buttonTextVariants, buttonVariants };
-export type { ButtonProps, ButtonTextProps };
+export { Button, buttonTextVariants, buttonVariants };
+export type { ButtonProps };

--- a/components/universal-ui/card.tsx
+++ b/components/universal-ui/card.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Text, View } from 'react-native';
+import { TextClassContext } from '~/components/universal-ui/typography';
 import { TextRef, ViewRef } from '~/lib/rn-primitives/types';
-
 import { cn } from '~/lib/utils';
 
 const Card = React.forwardRef<
@@ -64,7 +64,9 @@ const CardContent = React.forwardRef<
   ViewRef,
   React.ComponentPropsWithoutRef<typeof View>
 >(({ className, ...props }, ref) => (
-  <View ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  <TextClassContext.Provider value='text-card-foreground'>
+    <View ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  </TextClassContext.Provider>
 ));
 CardContent.displayName = 'CardContent';
 
@@ -80,24 +82,11 @@ const CardFooter = React.forwardRef<
 ));
 CardFooter.displayName = 'CardFooter';
 
-const CardText = React.forwardRef<
-  TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => (
-  <Text
-    ref={ref}
-    className={cn('text-card-foreground', className)}
-    {...props}
-  />
-));
-CardTitle.displayName = 'CardTitle';
-
 export {
   Card,
   CardContent,
   CardDescription,
   CardFooter,
   CardHeader,
-  CardText,
   CardTitle,
 };

--- a/components/universal-ui/context-menu.tsx
+++ b/components/universal-ui/context-menu.tsx
@@ -14,8 +14,8 @@ import {
   ViewStyle,
 } from 'react-native';
 import * as ContextMenuPrimitive from '~/lib/rn-primitives/context-menu';
-import { TextRef } from '~/lib/rn-primitives/types';
 import { cn } from '~/lib/utils';
+import { TextClassContext } from '~/components/universal-ui/typography';
 
 const ContextMenu = ContextMenuPrimitive.Root;
 
@@ -39,41 +39,29 @@ const ContextMenuSubTrigger = React.forwardRef<
   const Icon =
     Platform.OS === 'web' ? ChevronRight : open ? ChevronUp : ChevronDown;
   return (
-    <ContextMenuPrimitive.SubTrigger
-      ref={ref}
-      className={cn(
-        'flex flex-row web:cursor-default select-none items-center gap-2 focus:bg-accent active:bg-accent hover:bg-accent rounded-sm px-2 py-1.5 native:py-2 web:outline-none',
-        open && 'bg-accent',
-        inset && 'pl-8',
-        className
+    <TextClassContext.Provider
+      value={cn(
+        'select-none text-sm native:text-lg text-primary',
+        open && 'native:text-accent-foreground'
       )}
-      {...props}
     >
-      <>{children}</>
-      <Icon size={18} className='ml-auto text-foreground' />
-    </ContextMenuPrimitive.SubTrigger>
+      <ContextMenuPrimitive.SubTrigger
+        ref={ref}
+        className={cn(
+          'flex flex-row web:cursor-default select-none items-center gap-2 focus:bg-accent active:bg-accent hover:bg-accent rounded-sm px-2 py-1.5 native:py-2 web:outline-none',
+          open && 'bg-accent',
+          inset && 'pl-8',
+          className
+        )}
+        {...props}
+      >
+        <>{children}</>
+        <Icon size={18} className='ml-auto text-foreground' />
+      </ContextMenuPrimitive.SubTrigger>
+    </TextClassContext.Provider>
   );
 });
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
-
-const ContextMenuSubTriggerText = React.forwardRef<
-  TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  const { open } = ContextMenuPrimitive.useSubContext();
-  return (
-    <Text
-      ref={ref}
-      className={cn(
-        'select-none text-sm native:text-lg text-primary',
-        open && 'native:text-accent-foreground',
-        className
-      )}
-      {...props}
-    />
-  );
-});
-ContextMenuSubTriggerText.displayName = 'ContextMenuSubTriggerText';
 
 const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
@@ -142,35 +130,20 @@ const ContextMenuItem = React.forwardRef<
     inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex flex-row web:cursor-default items-center gap-2 rounded-sm px-2 py-1.5 native:py-2 web:outline-none focus:bg-accent active:bg-accent hover:bg-accent group',
-      inset && 'pl-8',
-      props.disabled && 'opacity-50 web:pointer-events-none',
-      className
-    )}
-    {...props}
-  />
-));
-ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
-
-const ContextMenuItemText = React.forwardRef<
-  TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  return (
-    <Text
+  <TextClassContext.Provider value='select-none text-sm native:text-lg text-popover-foreground group-focus:text-accent-foreground'>
+    <ContextMenuPrimitive.Item
       ref={ref}
       className={cn(
-        'select-none text-sm native:text-lg text-popover-foreground group-focus:text-accent-foreground',
+        'relative flex flex-row web:cursor-default items-center gap-2 rounded-sm px-2 py-1.5 native:py-2 web:outline-none focus:bg-accent active:bg-accent hover:bg-accent group',
+        inset && 'pl-8',
+        props.disabled && 'opacity-50 web:pointer-events-none',
         className
       )}
       {...props}
     />
-  );
-});
-ContextMenuItemText.displayName = 'ContextMenuItemText';
+  </TextClassContext.Provider>
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
 
 const ContextMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
@@ -272,7 +245,6 @@ export {
   ContextMenuContent,
   ContextMenuGroup,
   ContextMenuItem,
-  ContextMenuItemText,
   ContextMenuLabel,
   ContextMenuPortal,
   ContextMenuRadioGroup,
@@ -282,6 +254,5 @@ export {
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
-  ContextMenuSubTriggerText,
   ContextMenuTrigger,
 };

--- a/components/universal-ui/dropdown-menu.tsx
+++ b/components/universal-ui/dropdown-menu.tsx
@@ -13,8 +13,8 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
+import { TextClassContext } from '~/components/universal-ui/typography';
 import * as DropdownMenuPrimitive from '~/lib/rn-primitives/dropdown-menu';
-import { TextRef } from '~/lib/rn-primitives/types';
 import { cn } from '~/lib/utils';
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
@@ -39,42 +39,30 @@ const DropdownMenuSubTrigger = React.forwardRef<
   const Icon =
     Platform.OS === 'web' ? ChevronRight : open ? ChevronUp : ChevronDown;
   return (
-    <DropdownMenuPrimitive.SubTrigger
-      ref={ref}
-      className={cn(
-        'flex flex-row web:cursor-default select-none gap-2 items-center focus:bg-accent hover:bg-accent active:bg-accent rounded-sm px-2 py-1.5 native:py-2 web:outline-none',
-        open && 'bg-accent',
-        inset && 'pl-8',
-        className
+    <TextClassContext.Provider
+      value={cn(
+        'select-none text-sm native:text-lg text-primary',
+        open && 'native:text-accent-foreground'
       )}
-      {...props}
     >
-      <>{children}</>
-      <Icon size={18} className='ml-auto text-foreground' />
-    </DropdownMenuPrimitive.SubTrigger>
+      <DropdownMenuPrimitive.SubTrigger
+        ref={ref}
+        className={cn(
+          'flex flex-row web:cursor-default select-none gap-2 items-center focus:bg-accent hover:bg-accent active:bg-accent rounded-sm px-2 py-1.5 native:py-2 web:outline-none',
+          open && 'bg-accent',
+          inset && 'pl-8',
+          className
+        )}
+        {...props}
+      >
+        <>{children}</>
+        <Icon size={18} className='ml-auto text-foreground' />
+      </DropdownMenuPrimitive.SubTrigger>
+    </TextClassContext.Provider>
   );
 });
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName;
-
-const DropdownMenuSubTriggerText = React.forwardRef<
-  TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  const { open } = DropdownMenuPrimitive.useSubContext();
-  return (
-    <Text
-      ref={ref}
-      className={cn(
-        'select-none text-sm native:text-lg text-primary',
-        open && 'native:text-accent-foreground',
-        className
-      )}
-      {...props}
-    />
-  );
-});
-DropdownMenuSubTriggerText.displayName = 'DropdownMenuSubTriggerText';
 
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
@@ -112,7 +100,7 @@ const DropdownMenuContent = React.forwardRef<
         style={
           overlayStyle
             ? StyleSheet.flatten([
-                Platform.OS !== 'web' ? StyleSheet.absoluteFill : {},
+                Platform.OS !== 'web' ? StyleSheet.absoluteFill : undefined,
                 overlayStyle,
               ])
             : Platform.OS !== 'web'
@@ -144,35 +132,20 @@ const DropdownMenuItem = React.forwardRef<
     inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex flex-row web:cursor-default gap-2 items-center rounded-sm px-2 py-1.5 native:py-2 web:outline-none focus:bg-accent active:bg-accent hover:bg-accent group',
-      inset && 'pl-8',
-      props.disabled && 'opacity-50 web:pointer-events-none',
-      className
-    )}
-    {...props}
-  />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
-
-const DropdownMenuItemText = React.forwardRef<
-  TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  return (
-    <Text
+  <TextClassContext.Provider value='select-none text-sm native:text-lg text-popover-foreground group-focus:text-accent-foreground'>
+    <DropdownMenuPrimitive.Item
       ref={ref}
       className={cn(
-        'select-none text-sm native:text-lg text-popover-foreground group-focus:text-accent-foreground',
+        'relative flex flex-row web:cursor-default gap-2 items-center rounded-sm px-2 py-1.5 native:py-2 web:outline-none focus:bg-accent active:bg-accent hover:bg-accent group',
+        inset && 'pl-8',
+        props.disabled && 'opacity-50 web:pointer-events-none',
         className
       )}
       {...props}
     />
-  );
-});
-DropdownMenuItemText.displayName = 'DropdownMenuItemText';
+  </TextClassContext.Provider>
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
@@ -274,7 +247,6 @@ export {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuItemText,
   DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuRadioGroup,
@@ -284,6 +256,5 @@ export {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuSubTriggerText,
   DropdownMenuTrigger,
 };

--- a/components/universal-ui/hover-card.tsx
+++ b/components/universal-ui/hover-card.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Platform, StyleSheet, Text } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
+import { TextClassContext } from '~/components/universal-ui/typography';
 import * as HoverCardPrimitive from '~/lib/rn-primitives/hover-card';
-import { TextRef } from '~/lib/rn-primitives/types';
 import { cn } from '~/lib/utils';
 
 const HoverCard = HoverCardPrimitive.Root;
@@ -20,19 +20,21 @@ const HoverCardContent = React.forwardRef<
         style={Platform.OS !== 'web' ? StyleSheet.absoluteFill : undefined}
       >
         <Animated.View entering={FadeIn}>
-          <HoverCardPrimitive.Content
-            ref={ref}
-            align={align}
-            sideOffset={sideOffset}
-            className={cn(
-              'z-50 w-64 rounded-md border border-border bg-popover p-4 shadow-md web:outline-none web:cursor-auto data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-              open
-                ? 'web:animate-in  web:fade-in-0 web:zoom-in-95'
-                : 'web:animate-out web:fade-out-0 web:zoom-out-95 ',
-              className
-            )}
-            {...props}
-          />
+          <TextClassContext.Provider value='text-popover-foreground'>
+            <HoverCardPrimitive.Content
+              ref={ref}
+              align={align}
+              sideOffset={sideOffset}
+              className={cn(
+                'z-50 w-64 rounded-md border border-border bg-popover p-4 shadow-md web:outline-none web:cursor-auto data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+                open
+                  ? 'web:animate-in  web:fade-in-0 web:zoom-in-95'
+                  : 'web:animate-out web:fade-out-0 web:zoom-out-95 ',
+                className
+              )}
+              {...props}
+            />
+          </TextClassContext.Provider>
         </Animated.View>
       </HoverCardPrimitive.Overlay>
     </HoverCardPrimitive.Portal>
@@ -40,18 +42,4 @@ const HoverCardContent = React.forwardRef<
 });
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 
-const HoverCardContentText = React.forwardRef<
-  TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  return (
-    <Text
-      ref={ref}
-      className={cn('text-popover-foreground', className)}
-      {...props}
-    />
-  );
-});
-HoverCardContentText.displayName = 'HoverCardContentText';
-
-export { HoverCard, HoverCardContent, HoverCardTrigger, HoverCardContentText };
+export { HoverCard, HoverCardContent, HoverCardTrigger };

--- a/components/universal-ui/label.tsx
+++ b/components/universal-ui/label.tsx
@@ -1,7 +1,6 @@
+import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 import * as LabelPrimitive from '~/lib/rn-primitives/label';
-import { cva, type VariantProps } from 'class-variance-authority';
-
 import { cn } from '~/lib/utils';
 
 const labelVariants = cva(

--- a/components/universal-ui/menubar.tsx
+++ b/components/universal-ui/menubar.tsx
@@ -6,8 +6,8 @@ import {
 } from 'lucide-react-native';
 import * as React from 'react';
 import { Platform, Text, View } from 'react-native';
+import { TextClassContext } from '~/components/universal-ui/typography';
 import * as MenubarPrimitive from '~/lib/rn-primitives/menubar';
-import { TextRef } from '~/lib/rn-primitives/types';
 import { cn } from '~/lib/utils';
 
 const MenubarMenu = MenubarPrimitive.Menu;
@@ -66,41 +66,29 @@ const MenubarSubTrigger = React.forwardRef<
   const Icon =
     Platform.OS === 'web' ? ChevronRight : open ? ChevronUp : ChevronDown;
   return (
-    <MenubarPrimitive.SubTrigger
-      ref={ref}
-      className={cn(
-        'flex flex-row web:cursor-default select-none items-center gap-2 focus:bg-accent active:bg-accent hover:bg-accent rounded-sm px-2 py-1.5 native:py-2 web:outline-none',
-        open && 'bg-accent',
-        inset && 'pl-8',
-        className
+    <TextClassContext.Provider
+      value={cn(
+        'select-none text-sm native:text-lg text-primary',
+        open && 'native:text-accent-foreground'
       )}
-      {...props}
     >
-      <>{children}</>
-      <Icon size={18} className='ml-auto text-foreground' />
-    </MenubarPrimitive.SubTrigger>
+      <MenubarPrimitive.SubTrigger
+        ref={ref}
+        className={cn(
+          'flex flex-row web:cursor-default select-none items-center gap-2 focus:bg-accent active:bg-accent hover:bg-accent rounded-sm px-2 py-1.5 native:py-2 web:outline-none',
+          open && 'bg-accent',
+          inset && 'pl-8',
+          className
+        )}
+        {...props}
+      >
+        <>{children}</>
+        <Icon size={18} className='ml-auto text-foreground' />
+      </MenubarPrimitive.SubTrigger>
+    </TextClassContext.Provider>
   );
 });
 MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName;
-
-const MenubarSubTriggerText = React.forwardRef<
-  TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  const { open } = MenubarPrimitive.useSubContext();
-  return (
-    <Text
-      ref={ref}
-      className={cn(
-        'select-none text-sm native:text-lg text-primary',
-        open && 'native:text-accent-foreground',
-        className
-      )}
-      {...props}
-    />
-  );
-});
-MenubarSubTriggerText.displayName = 'MenubarSubTriggerText';
 
 const MenubarSubContent = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.SubContent>,
@@ -153,35 +141,20 @@ const MenubarItem = React.forwardRef<
     inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
-  <MenubarPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex flex-row web:cursor-default items-center gap-2 rounded-sm px-2 py-1.5 native:py-2 web:outline-none focus:bg-accent active:bg-accent hover:bg-accent group',
-      inset && 'pl-8',
-      props.disabled && 'opacity-50 web:pointer-events-none',
-      className
-    )}
-    {...props}
-  />
-));
-MenubarItem.displayName = MenubarPrimitive.Item.displayName;
-
-const MenubarItemText = React.forwardRef<
-  TextRef,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  return (
-    <Text
+  <TextClassContext.Provider value='select-none text-sm native:text-lg text-popover-foreground group-focus:text-accent-foreground'>
+    <MenubarPrimitive.Item
       ref={ref}
       className={cn(
-        'select-none text-sm native:text-lg text-popover-foreground group-focus:text-accent-foreground',
+        'relative flex flex-row web:cursor-default items-center gap-2 rounded-sm px-2 py-1.5 native:py-2 web:outline-none focus:bg-accent active:bg-accent hover:bg-accent group',
+        inset && 'pl-8',
+        props.disabled && 'opacity-50 web:pointer-events-none',
         className
       )}
       {...props}
     />
-  );
-});
-MenubarItemText.displayName = 'MenubarItemText';
+  </TextClassContext.Provider>
+));
+MenubarItem.displayName = MenubarPrimitive.Item.displayName;
 
 const MenubarCheckboxItem = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.CheckboxItem>,
@@ -282,7 +255,6 @@ export {
   MenubarContent,
   MenubarGroup,
   MenubarItem,
-  MenubarItemText,
   MenubarLabel,
   MenubarMenu,
   MenubarPortal,

--- a/components/universal-ui/popover.tsx
+++ b/components/universal-ui/popover.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import { Platform, StyleSheet, Text } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { TextClassContext } from '~/components/universal-ui/typography';
 import * as PopoverPrimitive from '~/lib/rn-primitives/popover';
-import * as Slot from '~/lib/rn-primitives/slot';
-import { SlottableTextProps, TextRef } from '~/lib/rn-primitives/types';
-
 import { cn } from '~/lib/utils';
 
 const Popover = PopoverPrimitive.Root;
@@ -15,26 +13,24 @@ const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = 'center', sideOffset = 4, ...props }, ref) => {
-  const open = true;
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Overlay
         style={Platform.OS !== 'web' ? StyleSheet.absoluteFill : undefined}
       >
         <Animated.View entering={FadeIn} exiting={FadeOut}>
-          <PopoverPrimitive.Content
-            ref={ref}
-            align={align}
-            sideOffset={sideOffset}
-            className={cn(
-              'z-50 w-72 rounded-md web:cursor-auto border border-border bg-popover p-4 shadow-md web:outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-              open
-                ? 'web:animate-in web:zoom-in-95 web:fade-in-0'
-                : 'web:animate-out web:fade-out-0 web:zoom-out-95',
-              className
-            )}
-            {...props}
-          />
+          <TextClassContext.Provider value='text-popover-foreground'>
+            <PopoverPrimitive.Content
+              ref={ref}
+              align={align}
+              sideOffset={sideOffset}
+              className={cn(
+                'z-50 w-72 rounded-md web:cursor-auto border border-border bg-popover p-4 shadow-md web:outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 web:animate-in web:zoom-in-95 web:fade-in-0',
+                className
+              )}
+              {...props}
+            />
+          </TextClassContext.Provider>
         </Animated.View>
       </PopoverPrimitive.Overlay>
     </PopoverPrimitive.Portal>
@@ -42,18 +38,4 @@ const PopoverContent = React.forwardRef<
 });
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-const PopoverText = React.forwardRef<TextRef, SlottableTextProps>(
-  ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
-    return (
-      <Component
-        ref={ref}
-        className={cn('text-popover-foreground', className)}
-        {...props}
-      />
-    );
-  }
-);
-PopoverText.displayName = 'PopoverText';
-
-export { Popover, PopoverTrigger, PopoverContent, PopoverText };
+export { Popover, PopoverContent, PopoverTrigger };

--- a/components/universal-ui/tabs.tsx
+++ b/components/universal-ui/tabs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text } from 'react-native';
+import { TextClassContext } from '~/components/universal-ui/typography';
 import * as TabsPrimitive from '~/lib/rn-primitives/tabs';
 import { cn } from '~/lib/utils';
 
@@ -26,39 +26,26 @@ const TabsTrigger = React.forwardRef<
 >(({ className, ...props }, ref) => {
   const { value } = TabsPrimitive.useRootContext();
   return (
-    <TabsPrimitive.Trigger
-      ref={ref}
-      className={cn(
-        'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background web:transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-        props.disabled && 'web:pointer-events-none opacity-50',
-        props.value === value && 'bg-background shadow-sm',
-        className
+    <TextClassContext.Provider
+      value={cn(
+        'text-sm native:text-base font-medium text-muted-foreground web:transition-all',
+        value === props.value && 'text-foreground'
       )}
-      {...props}
-    />
+    >
+      <TabsPrimitive.Trigger
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background web:transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          props.disabled && 'web:pointer-events-none opacity-50',
+          props.value === value && 'bg-background shadow-sm',
+          className
+        )}
+        {...props}
+      />
+    </TextClassContext.Provider>
   );
 });
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
-
-const TabsTriggerText = React.forwardRef<
-  React.ElementRef<typeof Text>,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  const { value } = TabsPrimitive.useRootContext();
-  const { value: triggerValue } = TabsPrimitive.useTriggerContext();
-  return (
-    <Text
-      ref={ref}
-      className={cn(
-        'text-sm native:text-base font-medium text-muted-foreground web:transition-all',
-        value === triggerValue && 'text-foreground',
-        className
-      )}
-      {...props}
-    />
-  );
-});
-TabsTriggerText.displayName = 'TabsTriggerText';
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -75,4 +62,4 @@ const TabsContent = React.forwardRef<
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerText };
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/components/universal-ui/toggle.tsx
+++ b/components/universal-ui/toggle.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as LucideIcon from 'lucide-react-native';
 import * as React from 'react';
-import { Text } from 'react-native';
+import { TextClassContext } from '~/components/universal-ui/typography';
 import * as TogglePrimitive from '~/lib/rn-primitives/toggle';
 import { cn } from '~/lib/utils';
 
@@ -49,16 +49,20 @@ const toggleTextVariants = cva(
   }
 );
 
-const ToggleContext = React.createContext<
-  ({ pressed: boolean } & VariantProps<typeof toggleVariants>) | null
->(null);
-
 const Toggle = React.forwardRef<
   React.ElementRef<typeof TogglePrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
     VariantProps<typeof toggleVariants>
 >(({ className, variant, size, ...props }, ref) => (
-  <ToggleContext.Provider value={{ pressed: props.pressed, variant, size }}>
+  <TextClassContext.Provider
+    value={cn(
+      toggleTextVariants({ variant, size }),
+      props.pressed
+        ? 'text-accent-foreground'
+        : 'group-hover:text-muted-foreground',
+      className
+    )}
+  >
     <TogglePrimitive.Root
       ref={ref}
       className={cn(
@@ -69,42 +73,10 @@ const Toggle = React.forwardRef<
       )}
       {...props}
     />
-  </ToggleContext.Provider>
+  </TextClassContext.Provider>
 ));
 
 Toggle.displayName = TogglePrimitive.Root.displayName;
-
-function useToggleContext() {
-  const context = React.useContext(ToggleContext);
-  if (context === null) {
-    throw new Error(
-      'Toggle compound components cannot be rendered outside the Toggle component'
-    );
-  }
-  return context;
-}
-
-const ToggleText = React.forwardRef<
-  React.ElementRef<typeof Text>,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  const { pressed, variant, size } = useToggleContext();
-  return (
-    <Text
-      ref={ref}
-      className={cn(
-        toggleTextVariants({ variant, size }),
-        pressed
-          ? 'text-accent-foreground'
-          : 'group-hover:text-muted-foreground',
-        className
-      )}
-      {...props}
-    />
-  );
-});
-
-ToggleText.displayName = 'ToggleText';
 
 const ToggleIcon = React.forwardRef<
   React.ElementRef<LucideIcon.Icon>,
@@ -112,24 +84,12 @@ const ToggleIcon = React.forwardRef<
     name: keyof typeof LucideIcon;
   }
 >(({ className, name, ...props }, ref) => {
-  const { pressed, variant } = useToggleContext();
+  const textClass = React.useContext(TextClassContext);
 
   const Icon = LucideIcon[name] as LucideIcon.Icon;
-  return (
-    <Icon
-      ref={ref}
-      className={cn(
-        toggleTextVariants({ variant }),
-        pressed
-          ? 'text-accent-foreground'
-          : 'group-hover:text-muted-foreground',
-        className
-      )}
-      {...props}
-    />
-  );
+  return <Icon ref={ref} className={cn(textClass, className)} {...props} />;
 });
 
 ToggleIcon.displayName = 'ToggleIcon';
 
-export { Toggle, ToggleText, ToggleIcon, toggleVariants, toggleTextVariants };
+export { Toggle, ToggleIcon, toggleTextVariants, toggleVariants };

--- a/components/universal-ui/tooltip.tsx
+++ b/components/universal-ui/tooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Text, StyleSheet, Platform } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { TextClassContext } from '~/components/universal-ui/typography';
 import * as TooltipPrimitive from '~/lib/rn-primitives/tooltip';
 import { cn } from '~/lib/utils';
 
@@ -17,37 +18,21 @@ const TooltipContent = React.forwardRef<
       style={Platform.OS !== 'web' ? StyleSheet.absoluteFill : undefined}
     >
       <Animated.View entering={FadeIn} exiting={FadeOut}>
-        <TooltipPrimitive.Content
-          ref={ref}
-          sideOffset={sideOffset}
-          className={cn(
-            'z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 shadow-md web:animate-in web:fade-in-0 web:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-            className
-          )}
-          {...props}
-        />
+        <TextClassContext.Provider value='text-sm native:text-base text-popover-foreground'>
+          <TooltipPrimitive.Content
+            ref={ref}
+            sideOffset={sideOffset}
+            className={cn(
+              'z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 shadow-md web:animate-in web:fade-in-0 web:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+              className
+            )}
+            {...props}
+          />
+        </TextClassContext.Provider>
       </Animated.View>
     </TooltipPrimitive.Overlay>
   </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
-const TooltipText = React.forwardRef<
-  React.ElementRef<typeof Text>,
-  React.ComponentPropsWithoutRef<typeof Text>
->(({ className, ...props }, ref) => {
-  return (
-    <Text
-      className={cn(
-        'text-sm native:text-base text-popover-foreground',
-        className
-      )}
-      ref={ref}
-      {...props}
-    />
-  );
-});
-
-TooltipText.displayName = 'TooltipText';
-
-export { Tooltip, TooltipContent, TooltipText, TooltipTrigger };
+export { Tooltip, TooltipContent, TooltipTrigger };

--- a/components/universal-ui/typography.tsx
+++ b/components/universal-ui/typography.tsx
@@ -1,19 +1,42 @@
 import * as Slot from '~/lib/rn-primitives/slot';
 import { SlottableTextProps, TextRef } from '~/lib/rn-primitives/types';
-
-import { Platform, Text } from 'react-native';
+import { Platform } from 'react-native';
 import { cn } from '~/lib/utils';
-import React from 'react';
+import * as React from 'react';
+import { Text as RNText } from 'react-native';
+
+const TextClassContext = React.createContext<string | undefined>(undefined);
+
+const Text = React.forwardRef<TextRef, SlottableTextProps>(
+  ({ className, asChild = false, ...props }, ref) => {
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
+    return (
+      <Component
+        className={cn(
+          'text-base text-foreground web:select-text',
+          textClass,
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Text.displayName = 'Text';
 
 const H1 = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         role='heading'
         aria-level='1'
         className={cn(
           'web:scroll-m-20 text-4xl text-foreground font-extrabold tracking-tight lg:text-5xl web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -27,13 +50,15 @@ H1.displayName = 'H1';
 
 const H2 = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         role='heading'
         aria-level='2'
         className={cn(
           'web:scroll-m-20 border-b border-border pb-2 text-3xl text-foreground font-semibold tracking-tight first:mt-0 web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -47,13 +72,15 @@ H2.displayName = 'H2';
 
 const H3 = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         role='heading'
         aria-level='3'
         className={cn(
           'web:scroll-m-20 text-2xl text-foreground font-semibold tracking-tight web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -67,13 +94,15 @@ H3.displayName = 'H3';
 
 const H4 = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         role='heading'
         aria-level='4'
         className={cn(
           'web:scroll-m-20 text-xl text-foreground font-semibold tracking-tight web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -85,33 +114,19 @@ const H4 = React.forwardRef<TextRef, SlottableTextProps>(
 
 H4.displayName = 'H4';
 
-const P = React.forwardRef<TextRef, SlottableTextProps>(
-  ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
-    return (
-      <Component
-        className={cn(
-          'text-foreground text-base leading-7 web:select-text',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-
-P.displayName = 'P';
+const P = Text;
 
 const BlockQuote = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         // @ts-ignore - role of blockquote renders blockquote element on the web
         role={Platform.OS === 'web' ? 'blockquote' : undefined}
         className={cn(
           'mt-6 native:mt-4 border-l-2 border-border pl-6 native:pl-3 text-base text-foreground italic web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -125,13 +140,15 @@ BlockQuote.displayName = 'BlockQuote';
 
 const Code = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         // @ts-ignore - role of code renders code element on the web
         role={Platform.OS === 'web' ? 'code' : undefined}
         className={cn(
           'relative rounded-md bg-muted px-[0.3rem] py-[0.2rem] text-sm text-foreground font-semibold web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -145,11 +162,13 @@ Code.displayName = 'Code';
 
 const Lead = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         className={cn(
           'text-xl text-muted-foreground web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -163,11 +182,13 @@ Lead.displayName = 'Lead';
 
 const Large = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         className={cn(
           'text-xl text-foreground font-semibold web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -181,11 +202,13 @@ Large.displayName = 'Large';
 
 const Small = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         className={cn(
           'text-sm text-foreground font-medium leading-none web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -199,11 +222,13 @@ Small.displayName = 'Small';
 
 const Muted = React.forwardRef<TextRef, SlottableTextProps>(
   ({ className, asChild = false, ...props }, ref) => {
-    const Component = asChild ? Slot.Text : Text;
+    const textClass = React.useContext(TextClassContext);
+    const Component = asChild ? Slot.Text : RNText;
     return (
       <Component
         className={cn(
           'text-sm text-muted-foreground web:select-text',
+          textClass,
           className
         )}
         ref={ref}
@@ -215,4 +240,18 @@ const Muted = React.forwardRef<TextRef, SlottableTextProps>(
 
 Muted.displayName = 'Muted';
 
-export { H1, H2, H3, H4, P, BlockQuote, Code, Lead, Large, Small, Muted };
+export {
+  H1,
+  H2,
+  H3,
+  H4,
+  P,
+  BlockQuote,
+  Code,
+  Lead,
+  Large,
+  Small,
+  Muted,
+  Text,
+  TextClassContext,
+};


### PR DESCRIPTION
This will remove children text components like `<ButtonText />`. It will use a `<Text />` component from `typography`.

The Text component has a context that any parent can provide a className value for the text component. While using the `cn` utility function, undefined values from the context are ignored and the closest parent wins specificity.

Example:
```jsx
import { Text } from '~/components/universal-ui/typography';

const Parent = (props) => <TextClassContext.Provider value="text-blue-500"><View {...props} /> </ TextClassContext.Provider>

const Component = () => <Parent><Text>Content</ Text></ Parent>
```

The "Content" text in the Text component will be blue.