### PR TITLE
Fix: Issue 30 : fixes the checkbox animation on web export

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "jsxSingleQuote": true
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,13 +1,8 @@
-import React from 'react';
 import { Check } from 'lucide-react-native';
-
+import * as React from 'react';
+import { Pressable } from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
 import { cn } from '~/lib/utils';
-import { Pressable, View } from 'react-native';
-import Animated, {
-  Easing,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
 
 interface CheckboxProps {
   value: boolean;
@@ -16,47 +11,18 @@ interface CheckboxProps {
   iconSize?: number;
 }
 
-interface AnimatedCheckProps {
-  value: boolean;
-  size: number;
-  className: string;
-  opacity: number;
-}
-
-const AnimatedCheck = Animated.createAnimatedComponent(
-  React.forwardRef(
-    (
-      { value, size, className, opacity, ...props }: AnimatedCheckProps,
-      ref: React.ForwardedRef<any>
-    ) => {
-      return (
-        <View ref={ref} style={{ opacity }}>
-          <Check size={size} className={className} {...props} />
-        </View>
-      );
-    }
-  )
-);
-
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof Pressable>,
   Omit<React.ComponentPropsWithoutRef<typeof Pressable>, 'onPress'> &
     CheckboxProps
 >(({ className, value, onChange, iconClass, iconSize = 16, ...props }, ref) => {
-  const opacity = useSharedValue(0);
-
-  opacity.value = withTiming(value === true ? 1.0 : 0.0, {
-    duration: 250,
-    easing: Easing.inOut(Easing.ease),
-  });
-
   return (
     <Pressable
       ref={ref}
       role='checkbox'
       accessibilityState={{ checked: value }}
       className={cn(
-        'peer h-7 w-7 shrink-0 flex items-center bg-card justify-center rounded-md border border-primary ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',
+        'peer h-7 w-7 shrink-0 flex items-center bg-card justify-center rounded-md border border-primary web:ring-offset-background web:disabled:cursor-not-allowed web:disabled:opacity-50',
         className
       )}
       onPress={() => {
@@ -64,14 +30,11 @@ const Checkbox = React.forwardRef<
       }}
       {...props}
     >
-      <View />
-
-      <AnimatedCheck
-        size={iconSize || 16}
-        className={cn('text-foreground', iconClass) || ''}
-        value={value}
-        opacity={opacity}
-      />
+      {value && (
+        <Animated.View entering={FadeIn.duration(200)}>
+          <Check size={iconSize} className={cn('text-foreground', iconClass)} />
+        </Animated.View>
+      )}
     </Pressable>
   );
 });

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,9 +1,13 @@
-import React from 'react';
-import { Check } from 'lucide-react-native';
+import React from "react";
+import { Check } from "lucide-react-native";
 
-import { cn } from '~/lib/utils';
-import { Pressable, View } from 'react-native';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { cn } from "~/lib/utils";
+import { Pressable, View } from "react-native";
+import Animated, {
+  Easing,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 
 interface CheckboxProps {
   value: boolean;
@@ -12,20 +16,47 @@ interface CheckboxProps {
   iconSize?: number;
 }
 
-const AnimatedCheck = Animated.createAnimatedComponent(Check);
+interface AnimatedCheckProps {
+  value: boolean;
+  size: number;
+  className: string;
+  opacity: number;
+}
+
+const AnimatedCheck = Animated.createAnimatedComponent(
+  React.forwardRef(
+    (
+      { value, size, className, opacity, ...props }: AnimatedCheckProps,
+      ref: React.ForwardedRef<any>
+    ) => {
+      return (
+        <View ref={ref} style={{ opacity }}>
+          <Check size={size} className={className} {...props} />
+        </View>
+      );
+    }
+  )
+);
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof Pressable>,
-  Omit<React.ComponentPropsWithoutRef<typeof Pressable>, 'onPress'> &
+  Omit<React.ComponentPropsWithoutRef<typeof Pressable>, "onPress"> &
     CheckboxProps
 >(({ className, value, onChange, iconClass, iconSize = 16, ...props }, ref) => {
+  const opacity = useSharedValue(0);
+
+  opacity.value = withTiming(value === true ? 1.0 : 0.0, {
+    duration: 250,
+    easing: Easing.inOut(Easing.ease),
+  });
+
   return (
     <Pressable
       ref={ref}
-      role='checkbox'
+      role="checkbox"
       accessibilityState={{ checked: value }}
       className={cn(
-        'peer h-7 w-7 shrink-0 flex items-center bg-card justify-center rounded-md border border-primary ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',
+        "peer h-7 w-7 shrink-0 flex items-center bg-card justify-center rounded-md border border-primary ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       onPress={() => {
@@ -34,18 +65,17 @@ const Checkbox = React.forwardRef<
       {...props}
     >
       <View />
-      {value && (
-        <AnimatedCheck
-          entering={FadeIn.duration(200)}
-          exiting={FadeOut.duration(200)}
-          size={iconSize}
-          className={cn('text-foreground', iconClass)}
-        />
-      )}
+
+      <AnimatedCheck
+        size={iconSize || 16}
+        className={cn("text-foreground", iconClass) || ""}
+        value={value}
+        opacity={opacity}
+      />
     </Pressable>
   );
 });
 
-Checkbox.displayName = 'Checkbox';
+Checkbox.displayName = "Checkbox";
 
 export { Checkbox };

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -53,7 +53,7 @@ const Checkbox = React.forwardRef<
   return (
     <Pressable
       ref={ref}
-      role="checkbox"
+      role='checkbox'
       accessibilityState={{ checked: value }}
       className={cn(
         'peer h-7 w-7 shrink-0 flex items-center bg-card justify-center rounded-md border border-primary ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,11 +1,7 @@
 import { Check } from 'lucide-react-native';
 import * as React from 'react';
 import { Pressable } from 'react-native';
-import Animated, {
-  useDerivedValue,
-  withTiming,
-  useSharedValue,
-} from 'react-native-reanimated';
+import Animated, { withTiming, useSharedValue } from 'react-native-reanimated';
 import { cn } from '~/lib/utils';
 
 interface CheckboxProps {

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,7 +1,11 @@
 import { Check } from 'lucide-react-native';
 import * as React from 'react';
 import { Pressable } from 'react-native';
-import Animated, { FadeIn } from 'react-native-reanimated';
+import Animated, {
+  useDerivedValue,
+  withTiming,
+  useSharedValue,
+} from 'react-native-reanimated';
 import { cn } from '~/lib/utils';
 
 interface CheckboxProps {
@@ -16,6 +20,12 @@ const Checkbox = React.forwardRef<
   Omit<React.ComponentPropsWithoutRef<typeof Pressable>, 'onPress'> &
     CheckboxProps
 >(({ className, value, onChange, iconClass, iconSize = 16, ...props }, ref) => {
+  const opacity = useSharedValue(0);
+
+  opacity.value = withTiming(value === true ? 1.0 : 0.0, {
+    duration: 200,
+  });
+
   return (
     <Pressable
       ref={ref}
@@ -30,11 +40,9 @@ const Checkbox = React.forwardRef<
       }}
       {...props}
     >
-      {value && (
-        <Animated.View entering={FadeIn.duration(200)}>
-          <Check size={iconSize} className={cn('text-foreground', iconClass)} />
-        </Animated.View>
-      )}
+      <Animated.View style={{ opacity }}>
+        <Check size={iconSize} className={cn('text-foreground', iconClass)} />
+      </Animated.View>
     </Pressable>
   );
 });

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,13 +1,13 @@
-import React from "react";
-import { Check } from "lucide-react-native";
+import React from 'react';
+import { Check } from 'lucide-react-native';
 
-import { cn } from "~/lib/utils";
-import { Pressable, View } from "react-native";
+import { cn } from '~/lib/utils';
+import { Pressable, View } from 'react-native';
 import Animated, {
   Easing,
   useSharedValue,
   withTiming,
-} from "react-native-reanimated";
+} from 'react-native-reanimated';
 
 interface CheckboxProps {
   value: boolean;
@@ -40,7 +40,7 @@ const AnimatedCheck = Animated.createAnimatedComponent(
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof Pressable>,
-  Omit<React.ComponentPropsWithoutRef<typeof Pressable>, "onPress"> &
+  Omit<React.ComponentPropsWithoutRef<typeof Pressable>, 'onPress'> &
     CheckboxProps
 >(({ className, value, onChange, iconClass, iconSize = 16, ...props }, ref) => {
   const opacity = useSharedValue(0);
@@ -56,7 +56,7 @@ const Checkbox = React.forwardRef<
       role="checkbox"
       accessibilityState={{ checked: value }}
       className={cn(
-        "peer h-7 w-7 shrink-0 flex items-center bg-card justify-center rounded-md border border-primary ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+        'peer h-7 w-7 shrink-0 flex items-center bg-card justify-center rounded-md border border-primary ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       onPress={() => {
@@ -68,7 +68,7 @@ const Checkbox = React.forwardRef<
 
       <AnimatedCheck
         size={iconSize || 16}
-        className={cn("text-foreground", iconClass) || ""}
+        className={cn('text-foreground', iconClass) || ''}
         value={value}
         opacity={opacity}
       />
@@ -76,6 +76,6 @@ const Checkbox = React.forwardRef<
   );
 });
 
-Checkbox.displayName = "Checkbox";
+Checkbox.displayName = 'Checkbox';
 
 export { Checkbox };


### PR DESCRIPTION
This updates the Checkbox  to do 3 small things:
1. use a Forward Ref component on a View (not an SVG)
2. the 'hook' approach' via `useSharedValue` and `withTiming` hooks
3. animate `opacity` via the `useSharedValue`

This resolves https://github.com/mrzachnugent/react-native-reusables/issues/30

I also added a prettierrc.json at the root of the project that should match the existing code style (I noticed you favored single quotes over double, so this enforces that)