### PR TITLE
Fix: Issue 32:  Verbose logging about useLayoutEffect on server render with web-export with toast component

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "jsxSingleQuote": true
+}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,14 +1,24 @@
+import React from 'react';
 import { Pressable } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Toast, { ToastConfig } from 'react-native-toast-message';
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
 
 /**
+ * This suppresses an annoying, but nonbreaking warning
+ * when accessing `useLayoutEffect`on the server.
+ * See issue: https://github.com/mrzachnugent/react-native-reusables/issues/32
+ */
+if (typeof document === 'undefined') {
+  React.useLayoutEffect = React.useEffect;
+}
+
+/**
  * @docs https://github.com/calintamas/react-native-toast-message/blob/main/docs/quick-start.md
  */
 const TOAST_CONFIG: ToastConfig = {
   success: ({ text1, text2, onPress, props: { icon = 'CheckSquare' } }) => (
-    <Pressable onPress={onPress} className='px-6 w-full max-w-xl'>
+    <Pressable onPress={onPress} className='w-full max-w-xl px-6'>
       <Alert icon={icon} variant='success'>
         <AlertTitle>{text1}</AlertTitle>
         <AlertDescription>{text2}</AlertDescription>
@@ -16,7 +26,7 @@ const TOAST_CONFIG: ToastConfig = {
     </Pressable>
   ),
   error: ({ text1, text2, onPress, props: { icon = 'AlertTriangle' } }) => (
-    <Pressable onPress={onPress} className='px-6 w-full max-w-xl'>
+    <Pressable onPress={onPress} className='w-full max-w-xl px-6'>
       <Alert icon={icon} variant='destructive'>
         <AlertTitle>{text1}</AlertTitle>
         <AlertDescription>{text2}</AlertDescription>
@@ -24,7 +34,7 @@ const TOAST_CONFIG: ToastConfig = {
     </Pressable>
   ),
   base: ({ text1, text2, onPress, props: { icon = 'Info' } }) => (
-    <Pressable onPress={onPress} className='px-6 w-full max-w-xl'>
+    <Pressable onPress={onPress} className='w-full max-w-xl px-6'>
       <Alert icon={icon} variant='default'>
         <AlertTitle>{text1}</AlertTitle>
         <AlertDescription>{text2}</AlertDescription>

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
 
 /**
  * Temporary fix for warning when accessing useLayoutEffect on the server. See issue
- * https://github.com/mrzachnugent/react-native-reusables/issues/32
+ * https://github.com/calintamas/react-native-toast-message/issues/530
  */
 if (typeof document === 'undefined') {
   React.useLayoutEffect = React.useEffect;

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -5,9 +5,8 @@ import Toast, { ToastConfig } from 'react-native-toast-message';
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
 
 /**
- * This suppresses an annoying, but nonbreaking warning
- * when accessing `useLayoutEffect`on the server.
- * See issue: https://github.com/mrzachnugent/react-native-reusables/issues/32
+ * Temporary fix for warning when accessing useLayoutEffect on the server. See issue
+ * https://github.com/mrzachnugent/react-native-reusables/issues/32
  */
 if (typeof document === 'undefined') {
   React.useLayoutEffect = React.useEffect;

--- a/lib/useIsomorphicLayoutEffect.tsx
+++ b/lib/useIsomorphicLayoutEffect.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;

--- a/lib/useIsomorphicLayoutEffect.tsx
+++ b/lib/useIsomorphicLayoutEffect.tsx
@@ -1,4 +1,0 @@
-import * as React from 'react';
-
-export const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;


### PR DESCRIPTION
1. adds a line of code to prevent accessing function on server that causes verbose logging
2. adds a prettierrc.json that matches the existing code style