### PR TITLE
Fix issue 38: Radio: adds borders to the radio buttons on web same as mobile

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "jsxSingleQuote": true
+}

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { GestureResponderEvent, Pressable, View } from 'react-native';
-import { cn } from '~/lib/utils';
-import { Label } from './label';
+import React from "react";
+import { GestureResponderEvent, Pressable, View } from "react-native";
+import { cn } from "~/lib/utils";
+import { Label } from "./label";
 
 interface RadioGroupProps {
   defaultValue?: string;
@@ -23,7 +23,7 @@ const RadioGroup = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof View> & RadioGroupProps
 >(
   (
-    { defaultValue = '', onValueChange, className, disabled = false, ...props },
+    { defaultValue = "", onValueChange, className, disabled = false, ...props },
     ref
   ) => {
     const [value, setValue] = React.useState(defaultValue);
@@ -38,9 +38,9 @@ const RadioGroup = React.forwardRef<
         }}
       >
         <View
-          role='radiogroup'
+          role="radiogroup"
           ref={ref}
-          className={cn('gap-2', className)}
+          className={cn("gap-2", className)}
           {...props}
         />
       </RadioGroupContext.Provider>
@@ -48,13 +48,13 @@ const RadioGroup = React.forwardRef<
   }
 );
 
-RadioGroup.displayName = 'RadioGroup';
+RadioGroup.displayName = "RadioGroup";
 
 function useRadioGroupContext() {
   const context = React.useContext(RadioGroupContext);
   if (!context) {
     throw new Error(
-      'RadioGroup compound components cannot be rendered outside the RadioGroup component'
+      "RadioGroup compound components cannot be rendered outside the RadioGroup component"
     );
   }
   return context;
@@ -62,7 +62,7 @@ function useRadioGroupContext() {
 
 const RadioGroupItem = React.forwardRef<
   React.ElementRef<typeof Pressable>,
-  Omit<React.ComponentPropsWithoutRef<typeof Pressable>, 'disabled'> & {
+  Omit<React.ComponentPropsWithoutRef<typeof Pressable>, "disabled"> & {
     name: string;
     labelClass?: string;
     buttonClass?: string;
@@ -92,24 +92,24 @@ const RadioGroupItem = React.forwardRef<
     }
 
     return (
-      <View className={cn('flex-row gap-3 items-center', className)}>
+      <View className={cn("flex-row gap-3 items-center", className)}>
         <Pressable
           disabled={disabled}
           onPress={handleOnPress}
           className={cn(
-            'h-6 w-6 border-primary [borderWidth:1.5] rounded-full items-center justify-center',
+            "h-6 w-6 border-primary native:[borderWidth:1.5] web:border rounded-full items-center justify-center",
             buttonClass
           )}
           aria-labelledby={name}
           accessibilityState={{ selected: value === name }}
-          role='radio'
+          role="radio"
           {...props}
         >
           {value === name && (
             <View
               ref={ref}
               className={cn(
-                'h-3 w-3 bg-primary rounded-full',
+                "h-3 w-3 bg-primary rounded-full",
                 innerButtonClass
               )}
             />
@@ -117,7 +117,7 @@ const RadioGroupItem = React.forwardRef<
         </Pressable>
         <Label
           onPress={handleOnPress}
-          className={cn('text-xl', labelClass)}
+          className={cn("text-xl", labelClass)}
           nativeID={name}
         >
           {children}

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { GestureResponderEvent, Pressable, View } from "react-native";
-import { cn } from "~/lib/utils";
-import { Label } from "./label";
+import React from 'react';
+import { GestureResponderEvent, Pressable, View } from 'react-native';
+import { cn } from '~/lib/utils';
+import { Label } from './label';
 
 interface RadioGroupProps {
   defaultValue?: string;
@@ -23,7 +23,7 @@ const RadioGroup = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof View> & RadioGroupProps
 >(
   (
-    { defaultValue = "", onValueChange, className, disabled = false, ...props },
+    { defaultValue = '', onValueChange, className, disabled = false, ...props },
     ref
   ) => {
     const [value, setValue] = React.useState(defaultValue);
@@ -38,9 +38,9 @@ const RadioGroup = React.forwardRef<
         }}
       >
         <View
-          role="radiogroup"
+          role='radiogroup'
           ref={ref}
-          className={cn("gap-2", className)}
+          className={cn('gap-2', className)}
           {...props}
         />
       </RadioGroupContext.Provider>
@@ -48,13 +48,13 @@ const RadioGroup = React.forwardRef<
   }
 );
 
-RadioGroup.displayName = "RadioGroup";
+RadioGroup.displayName = 'RadioGroup';
 
 function useRadioGroupContext() {
   const context = React.useContext(RadioGroupContext);
   if (!context) {
     throw new Error(
-      "RadioGroup compound components cannot be rendered outside the RadioGroup component"
+      'RadioGroup compound components cannot be rendered outside the RadioGroup component'
     );
   }
   return context;
@@ -62,7 +62,7 @@ function useRadioGroupContext() {
 
 const RadioGroupItem = React.forwardRef<
   React.ElementRef<typeof Pressable>,
-  Omit<React.ComponentPropsWithoutRef<typeof Pressable>, "disabled"> & {
+  Omit<React.ComponentPropsWithoutRef<typeof Pressable>, 'disabled'> & {
     name: string;
     labelClass?: string;
     buttonClass?: string;
@@ -92,24 +92,24 @@ const RadioGroupItem = React.forwardRef<
     }
 
     return (
-      <View className={cn("flex-row gap-3 items-center", className)}>
+      <View className={cn('flex-row gap-3 items-center', className)}>
         <Pressable
           disabled={disabled}
           onPress={handleOnPress}
           className={cn(
-            "h-6 w-6 border-primary native:[borderWidth:1.5] web:border rounded-full items-center justify-center",
+            'h-6 w-6 border-primary native:[borderWidth:1.5] web:border rounded-full items-center justify-center',
             buttonClass
           )}
           aria-labelledby={name}
           accessibilityState={{ selected: value === name }}
-          role="radio"
+          role='radio'
           {...props}
         >
           {value === name && (
             <View
               ref={ref}
               className={cn(
-                "h-3 w-3 bg-primary rounded-full",
+                'h-3 w-3 bg-primary rounded-full',
                 innerButtonClass
               )}
             />
@@ -117,7 +117,7 @@ const RadioGroupItem = React.forwardRef<
         </Pressable>
         <Label
           onPress={handleOnPress}
-          className={cn("text-xl", labelClass)}
+          className={cn('text-xl', labelClass)}
           nativeID={name}
         >
           {children}


### PR DESCRIPTION
changes `[borderWidth:1.5] ` to `native:[borderWidth:1.5] web:border`

| Before | After  |
|--------|--------|
| ![image](https://github.com/mrzachnugent/react-native-reusables/assets/954596/75b8b196-b19a-475e-b9ab-039f0cce9bea)| ![image](https://github.com/mrzachnugent/react-native-reusables/assets/954596/c727076c-cc69-4c2b-b9f7-b9eb7920109f)| 