### PR TITLE
Switch fixes

### DIFF
--- a/packages/primitives/switch/src/switch.tsx
+++ b/packages/primitives/switch/src/switch.tsx
@@ -60,6 +60,6 @@ const Thumb = React.forwardRef<ViewRef, SlottableViewProps>(
   }
 );
 
-Root.displayName = 'RootNativeSwitch';
+Thumb.displayName = 'ThumbNativeSwitch';
 
 export { Root, Thumb };

--- a/packages/primitives/switch/src/switch.web.tsx
+++ b/packages/primitives/switch/src/switch.web.tsx
@@ -62,6 +62,6 @@ const Thumb = React.forwardRef<ViewRef, SlottableViewProps>(({ asChild, ...props
   );
 });
 
-Root.displayName = 'RootWebSwitch';
+Thumb.displayName = 'ThumbWebSwitch';
 
 export { Root, Thumb };

--- a/packages/reusables/src/components/ui/switch.tsx
+++ b/packages/reusables/src/components/ui/switch.tsx
@@ -45,7 +45,7 @@ const RGB_COLORS = {
     primary: 'rgb(250, 250, 250)',
     input: 'rgb(39, 39, 42)',
   },
-};
+} as const;
 
 const SwitchNative = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,


### PR DESCRIPTION
# Pull Request Template

## Description:
Fixes `displayName` for `Thumb` in `Switch` primitives (https://github.com/mrzachnugent/react-native-reusables/issues/109)

Additionally, adds a const assertion to `components/ui/switch.tsx` so the typecheck passes for line 61 of that same file:

```
const RGB_COLORS = {
  light: {
    primary: 'rgb(24, 24, 27)',
    input: 'rgb(228, 228, 231)',
  },
  dark: {
    primary: 'rgb(250, 250, 250)',
    input: 'rgb(39, 39, 42)',
  },
} as const;
```
