### PR TITLE
fix(ui): pressable component warning if new styles are introduced conditionally

### DIFF
--- a/packages/reusables/src/components/ui/tabs.tsx
+++ b/packages/reusables/src/components/ui/tabs.tsx
@@ -35,7 +35,7 @@ const TabsTrigger = React.forwardRef<
       <TabsPrimitive.Trigger
         ref={ref}
         className={cn(
-          'inline-flex items-center justify-center web:whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium web:ring-offset-background web:transition-all web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2',
+          'inline-flex items-center justify-center shadow-none web:whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium web:ring-offset-background web:transition-all web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2',
           props.disabled && 'web:pointer-events-none opacity-50',
           props.value === value && 'bg-background shadow-lg shadow-foreground/10',
           className


### PR DESCRIPTION
## Description:
<!-- Provide a brief description of the changes introduced by this pull request. -->

I don't actually know if this is a problem with react-native-reusables, it appears to be a peculiarity with nativewind according to [this issue](https://github.com/marklawlor/nativewind/issues/873). (interestingly somebody else has already mentioned rnr in the thread) Throwing this out here to raise awareness of the issue. I copy pasted the Tabs example and it straight up didn't render properly on react-native android. One of the issues was this one, will keep digging to figure out what are the other ones.

The warning i was getting:
```
WARN  CssInterop upgrade warning.

Making a component inheritable should only happen during the initial render otherwise it will remount the component.

To prevent this warning avoid dynamically adding CSS variables or 'container' styles to components after the initial render, or ensure it has a default style that sets either a CSS variable, "container: none" or "container-type: none".

If add/removing sibling components cause this warning, add a unique "key" prop so React can correctly track this component. 
    at CssInterop.Pressable (http://192.168.1.120:8081/node_modules/expo-router/entry.bundle//&platform=android&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:11004:45)
    at TriggerNativeTabs (http://192.168.1.120:8081/node_modules/expo-router/entry.bundle//&platform=android&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:333260:24)
    at TriggerNativeTabs (http://192.168.1.120:8081/components/ui/tabs.bundle//&platform=android&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true:35:26)
...


WARN  The previous warning was caused by a component with these props: ["nativeID","aria-disabled","aria-selected","role","onPress","accessibilityState","disabled","className","children"]. Some props could not be stringified, so only the keys are shown. 
    at CssInterop.Pressable (http://192.168.1.120:8081/node_modules/expo-router/entry.bundle//&platform=android&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:11004:45)
    at TriggerNativeTabs (http://192.168.1.120:8081/node_modules/expo-router/entry.bundle//&platform=android&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:333260:24)
    at TriggerNativeTabs (http://192.168.1.120:8081/components/ui/tabs.bundle//&platform=android&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true:35:26)
...
```

## Tested Platforms:
<!-- Check the platforms that you have tested this PR on. -->

- [ ] Web
- [ ] iOS
- [ ] Android

## Affected Apps/Packages:
<!-- Specify which apps or packages are affected by this pull request. -->

- ui

### Screenshots:
<!-- If applicable, add screenshots to showcase the changes visually. -->

#### Notes:
<!-- Add any additional notes or context that reviewers should be aware of. -->

