### PR TITLE
Popover not working on iOS

### DIFF
--- a/packages/primitives/popover/src/popover.tsx
+++ b/packages/primitives/popover/src/popover.tsx
@@ -75,7 +75,7 @@ function useRootContext() {
 
 const Trigger = React.forwardRef<PopoverTriggerRef, SlottablePressableProps>(
   ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
-    const { onOpenChange, setTriggerPosition } = useRootContext();
+    const { onOpenChange, open, setTriggerPosition } = useRootContext();
 
     const augmentedRef = useAugmentedRef({
       ref,


### PR DESCRIPTION
# Pull Request Template

This fixes one case but now running into another error:

```
 ERROR  ReanimatedError: Cannot convert undefined value to object, js engine: reanimated
```

```
 ERROR  Invariant Violation: Rotate transform must be expressed in degrees (deg) or radians (rad): {"rotate":"initial"}

This error is located at:
    in RCTView (created by CssInterop.View)
    in CssInterop.View (created by AnimatedComponent(View))
    in AnimatedComponent(View)
    in Unknown (created by CSSInteropAnimationWrapper(View))
    in CSSInteropAnimationWrapper(View) (created by CssInterop.View)
    in CssInterop.View (created by ContentNativePopover)
    in ContentNativePopover (created by ContentNativePopover)
    in RCTView (created by CssInterop.View)
    in CssInterop.View (created by AnimatedComponent(View))
    in AnimatedComponent(View)
    in Unknown (created by ContentNativePopover)
    in RCTView (created by CssInterop.View)
    in CssInterop.View (created by Pressable)
    in Pressable (created by Pressable)
    in CssInterop.Pressable (created by OverlayNativePopover)
    in OverlayNativePopover (created by ContentNativePopover)
    in PortalHost (created by Layout)
    in ThemeProvider (created by Layout)
    in RNCSafeAreaProvider (created by SafeAreaProvider)
```

## Tested Platforms:
<!-- Check the platforms that you have tested this PR on. -->

- [x] Web
- [x] iOS
- [ ] Android

