### PR TITLE
fix(ui): switch component ui bug & fix(docs): typo

### DIFF
--- a/apps/docs/src/content/docs/components/separator.mdx
+++ b/apps/docs/src/content/docs/components/separator.mdx
@@ -1,5 +1,5 @@
 ---
-title: Separtor
+title: Separator
 description: Creates a visual or semantic distinction between content.
 ---
 

--- a/packages/reusables/src/components/ui/switch.tsx
+++ b/packages/reusables/src/components/ui/switch.tsx
@@ -72,6 +72,7 @@ const SwitchNative = React.forwardRef<
       <SwitchPrimitives.Root
         className={cn(
           'flex-row h-8 w-[46px] shrink-0 items-center rounded-full border-2 border-transparent',
+          props.checked ? 'bg-primary' : 'bg-input',
           className
         )}
         {...props}


### PR DESCRIPTION
# Pull Request Template

## Description:

Typo Fix:
The title has a typo as "Separtor", https://rnr-docs.vercel.app/components/separator/

UI Bug fix:
The Web version of the Switch component has a condition as follows

```
const SwitchWeb = React.forwardRef<
  React.ElementRef<typeof SwitchPrimitives.Root>,
  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
>(({ className, ...props }, ref) => (
  <SwitchPrimitives.Root
    className={cn(
      "peer flex-row h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed",
      props.checked ? "bg-primary" : "bg-input",
      props.disabled && "opacity-50",  // THIS LINE
      className
    )}
    {...props}
    ref={ref}
  >
    <SwitchPrimitives.Thumb
      className={cn(
        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-md shadow-foreground/5 ring-0 transition-transform",
        props.checked ? "translate-x-5" : "translate-x-0"
      )}
    />
  </SwitchPrimitives.Root>
));
```

But there is no such condition in the Native component. This can cause UI bugs. So I added it.

Fixes #209 

## Tested Platforms:

- [ ] Web
- [ ] iOS
- [x] Android

## Affected Apps/Packages:
<!-- Specify which apps or packages are affected by this pull request. -->

- ui

### Screenshots:

#### Notes:


