### PR TITLE
Missing ./node_modules/.cache/nativewind/global.css

### DIFF
--- a/apps/starter-base/package.json
+++ b/apps/starter-base/package.json
@@ -9,7 +9,8 @@
     "android": "expo start -c --android",
     "ios": "expo start -c --ios",
     "web": "expo start -c --web",
-    "clean": "rm -rf .expo node_modules"
+    "clean": "rm -rf .expo node_modules",
+    "postinstall": "npx tailwindcss -i ./global.css -o ./node_modules/.cache/nativewind/global.css"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.23.1",


### PR DESCRIPTION
# Fix for `Missing ./node_modules/.cache/nativewind/global.css`

## Description:

After I try to run starter app I got the next error

```
Metro error: Unable to resolve module /mnt/c/users/user/documents/github/react-native-reusables/apps/starter-base/node_modules/.cache/nativewind/global.css from /mnt/c/users/user/documents/github/react-native-reusables/apps/starter-base/global.css:
```

## Tested Platforms:
<!-- Check the platforms that you have tested this PR on. -->

- [x] Web
- [x] iOS
- [x] Android

## Affected Apps/Packages:

- apps/starter-base

### Screenshots:

![image](https://github.com/user-attachments/assets/b0dbd44e-311e-4979-b3a2-7151d01a70c8)

#### Notes:

I think the postinstall script which exist in `apps\showcase\package.json` is missing

```json
"scripts": {
  "dev": "expo start -c --ios",
  "dev:web": "expo start -c --web",
  "dev:android": "expo start -c --android",
  "android": "expo start -c --android",
  "ios": "expo start -c --ios",
  "web": "expo start -c --web",
  "clean": "rm -rf .expo node_modules",
  "postinstall": "npx tailwindcss -i ./global.css -o ./node_modules/.cache/nativewind/global.css"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
},
```



