### PR TITLE
fix: unstable android navigation bar theme

### DIFF
--- a/apps/starter-base/app/_layout.tsx
+++ b/apps/starter-base/app/_layout.tsx
@@ -10,6 +10,7 @@ import { NAV_THEME } from '~/lib/constants';
 import { useColorScheme } from '~/lib/useColorScheme';
 import { PortalHost } from '@rn-primitives/portal';
 import { ThemeToggle } from '~/components/ThemeToggle';
+import { setAndroidNavigationBar } from '~/lib/android-navigation-bar';
 
 const LIGHT_THEME: Theme = {
   dark: false,
@@ -47,10 +48,11 @@ export default function RootLayout() {
       const colorTheme = theme === 'dark' ? 'dark' : 'light';
       if (colorTheme !== colorScheme) {
         setColorScheme(colorTheme);
-
+        setAndroidNavigationBar(colorTheme);
         setIsColorSchemeLoaded(true);
         return;
       }
+      setAndroidNavigationBar(colorTheme);
       setIsColorSchemeLoaded(true);
     })().finally(() => {
       SplashScreen.hideAsync();


### PR DESCRIPTION
# Pull Request Template

## Description:
When the app is first opened, safe area zones on Android are not updated to match the theme.


## Tested Platforms:
<!-- Check the platforms that you have tested this PR on. -->

- [ ] Web
- [ ] iOS
- [x] Android

## Affected Apps/Packages:

apps/starter-base

### Screenshots:
![image](https://github.com/user-attachments/assets/579cdcaa-7103-4d6c-af8e-2f3129ae3f07)

After:
![image](https://github.com/user-attachments/assets/bb8d0366-34eb-4737-88e8-d7778646edfb)