### PR TITLE
fix(dialog): remove z-50

### DIFF
--- a/packages/reusables/src/components/ui/dialog.tsx
+++ b/packages/reusables/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlayWeb = React.forwardRef<
   return (
     <DialogPrimitive.Overlay
       className={cn(
-        'z-50 bg-black/80 flex justify-center items-center p-2 absolute top-0 right-0 bottom-0 left-0',
+        'bg-black/80 flex justify-center items-center p-2 absolute top-0 right-0 bottom-0 left-0',
         open ? 'web:animate-in web:fade-in-0' : 'web:animate-out web:fade-out-0',
         className
       )}
@@ -40,7 +40,7 @@ const DialogOverlayNative = React.forwardRef<
   return (
     <DialogPrimitive.Overlay
       style={StyleSheet.absoluteFill}
-      className={cn('z-50 flex bg-black/80 justify-center items-center p-2', className)}
+      className={cn('flex bg-black/80 justify-center items-center p-2', className)}
       {...props}
       ref={ref}
     >
@@ -69,7 +69,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
           ref={ref}
           className={cn(
-            'z-50 max-w-lg gap-4 border border-border web:cursor-default bg-background p-6 shadow-lg web:duration-200 rounded-lg',
+            'max-w-lg gap-4 border border-border web:cursor-default bg-background p-6 shadow-lg web:duration-200 rounded-lg',
             open
               ? 'web:animate-in web:fade-in-0 web:zoom-in-95'
               : 'web:animate-out web:fade-out-0 web:zoom-out-95',


### PR DESCRIPTION
Prevent conflicting with other portal components such as tooltip and popover.

I am unsure why this was set. Nothing seems different when I remove it.

ETA: other portal components define the same thing.

