### PR TITLE
Add Sonner

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This project includes only components built without third-party libraries or tho
 
 ### Excluded components
 
-Only **14 out of the 50** shadcn/ui components are excluded from this library. However, you can use the following packages or repositories to build your own
+Only **13 out of the 50** shadcn/ui components are excluded from this library. However, you can use the following packages or repositories to build your own
 
 #### Calendar
 
@@ -83,10 +83,6 @@ _TBD_
 #### Sheet (Drawer navigation)
 
 - [Drawer navigation](https://reactnavigation.org/docs/drawer-based-navigation/): A drawer navigation component that slides in from the side.
-
-#### Sonner
-
-- [Burnt](https://www.npmjs.com/package/burnt): Cross-platform toasts for React Native, powered by native elements. On Web, it wraps [Sonner](https://github.com/emilkowalski/sonner).
 
 ### Community Templates
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ _TBD_
 
 #### Sonner
 
-_TBD_
+- [Burnt](https://www.npmjs.com/package/burnt): Cross-platform toasts for React Native, powered by native elements. On Web, it wraps [Sonner](https://github.com/emilkowalski/sonner).
 
 ### Community Templates
 

--- a/apps/showcase/app.json
+++ b/apps/showcase/app.json
@@ -39,7 +39,15 @@
     },
     "plugins": [
       "expo-router",
-      "expo-font"
+      "expo-font",
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "deploymentTarget": "13.0"
+          }
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/apps/showcase/app.json
+++ b/apps/showcase/app.json
@@ -39,15 +39,7 @@
     },
     "plugins": [
       "expo-router",
-      "expo-font",
-      [
-        "expo-build-properties",
-        {
-          "ios": {
-            "deploymentTarget": "13.0"
-          }
-        }
-      ]
+      "expo-font"
     ],
     "experiments": {
       "typedRoutes": true

--- a/apps/showcase/app/_layout.tsx
+++ b/apps/showcase/app/_layout.tsx
@@ -13,6 +13,7 @@ import { Text } from '~/components/ui/text';
 import { setAndroidNavigationBar } from '~/lib/android-navigation-bar';
 import { NAV_THEME } from '~/lib/constants';
 import { useColorScheme } from '~/lib/useColorScheme';
+import { Toaster } from 'burnt/web';
 
 const { ToastProvider } = DeprecatedUi;
 
@@ -105,6 +106,7 @@ export default function RootLayout() {
           </Stack>
         </BottomSheetModalProvider>
         <PortalHost />
+        <Toaster />
       </GestureHandlerRootView>
       <ToastProvider />
     </ThemeProvider>

--- a/apps/showcase/app/sonner.tsx
+++ b/apps/showcase/app/sonner.tsx
@@ -1,0 +1,53 @@
+import { View } from "react-native";
+import { Button } from "~/components/ui/button";
+import { Text } from "~/components/ui/text";
+import { Code } from '~/lib/icons/Code';
+import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
+import * as Burnt from "burnt";
+
+export default function SonnerScreen() {
+	function showSuccessToast() {
+		Burnt.toast({
+			title: "Success!",
+			message: "You have successfully completed the tutorial. You can now go touch some grass.",
+			preset: "done",
+		});
+	}
+	function showErrorToast() {
+		Burnt.toast({
+			title: "Danger!",
+			message: "High voltage. Do not touch. Risk of electric shock. Keep away from children.",
+			preset: "error",
+		});
+	}
+
+	function showBaseToast() {
+		Burnt.toast({
+			title: "Heads up!",
+			message: "You can use a terminal to run commands on your computer.",
+			preset: "none",
+		});
+	}
+	
+	return (
+		<>
+		<View className='flex-1 justify-center items-center gap-5'>
+		  <Button onPress={showSuccessToast}>
+			<Text>Show success toast</Text>
+		  </Button>
+		  <Button variant='destructive' onPress={showErrorToast}>
+			<Text>Show error toast</Text>
+		  </Button>
+		  <Button variant='secondary' onPress={showBaseToast}>
+			<Text>Show base toast</Text>
+		  </Button>
+		</View>
+		<View className='p-6 w-full'>
+		  <Alert icon={Code} className='max-w-xl mx-auto'>
+			<AlertTitle>FYI</AlertTitle>
+			<AlertDescription>This reusable wraps SPIndicator and AlertKit on iOS, and React Native's ToastAndroid on Android.</AlertDescription>
+		  </Alert>
+		</View>
+	  </>
+	);
+}

--- a/apps/showcase/lib/constants.ts
+++ b/apps/showcase/lib/constants.ts
@@ -33,6 +33,7 @@ export const COMPONENTS = [
   'progress',
   'radio-group',
   'select',
+  'sonner',
   'separator',
   'skeleton',
   'slider',

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -65,7 +65,9 @@
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.22.4",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "burnt": "latest",
+    "expo-build-properties": "latest"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -66,8 +66,7 @@
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.22.4",
     "zustand": "^4.4.7",
-    "burnt": "latest",
-    "expo-build-properties": "latest"
+    "burnt": "latest"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.11.7
         version: 8.13.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      burnt:
+        specifier: latest
+        version: 0.12.2(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0)))(react-dom@18.2.0(react@18.2.0))(react-native@0.74.3(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -152,6 +155,9 @@ importers:
       expo-blur:
         specifier: ~13.0.2
         version: 13.0.2(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0)))
+      expo-build-properties:
+        specifier: latest
+        version: 0.12.5(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0)))
       expo-clipboard:
         specifier: ~6.0.3
         version: 6.0.3(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0)))
@@ -3272,6 +3278,9 @@ packages:
       '@babel/runtime': '*'
       react: '*'
       react-native: '*'
+    peerDependenciesMeta:
+      '@babel/runtime':
+        optional: true
 
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -3859,6 +3868,13 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.17'
+
+  burnt@0.12.2:
+    resolution: {integrity: sha512-bbZjGN4Om7dykr8ZcLb0tTO5L2becMR+HIez1ySUGgG/rvK+ePgBEuBA6lMOZqOTsUXhIKFUBH0sCXQ25fq5SA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -4532,6 +4548,11 @@ packages:
 
   expo-blur@13.0.2:
     resolution: {integrity: sha512-t2p7BChO3Reykued++QJRMZ/og6J3aXtSQ+bU31YcBeXhZLkHwjWEhiPKPnJka7J2/yTs4+jOCNDY0kCZmcE3w==}
+    peerDependencies:
+      expo: '*'
+
+  expo-build-properties@0.12.5:
+    resolution: {integrity: sha512-donC1le0PYfLKCPKRMGQoixuWuwDWCngzXSoQXUPsgHTDHQUKr8aw+lcWkTwZcItgNovcnk784I0dyfYDcxybA==}
     peerDependencies:
       expo: '*'
 
@@ -7029,6 +7050,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sf-symbols-typescript@1.0.0:
+    resolution: {integrity: sha512-DkS7q3nN68dEMb4E18HFPDAvyrjDZK9YAQQF2QxeFu9gp2xRDXFMF8qLJ1EmQ/qeEGQmop4lmMM1WtYJTIcCMw==}
+    engines: {node: '>=10'}
+
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
@@ -7064,9 +7089,11 @@ packages:
 
   shikiji-core@0.9.19:
     resolution: {integrity: sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw==}
+    deprecated: Shikiji is merged back to Shiki v1.0, please migrate over to get the latest updates
 
   shikiji@0.9.19:
     resolution: {integrity: sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==}
+    deprecated: Shikiji is merged back to Shiki v1.0, please migrate over to get the latest updates
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -7106,6 +7133,12 @@ packages:
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
     engines: {node: '>=8.0.0'}
+
+  sonner@0.3.5:
+    resolution: {integrity: sha512-yIwaQ4dftMvFApuruto2t7wGyyaPRpj5qYBWYJIz4Z7uGcVn0IfqI/hWN0JyJN4izNbZFuCYZISf3fOGnvSlNQ==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
@@ -11516,11 +11549,12 @@ snapshots:
 
   '@shopify/flash-list@1.6.4(@babel/runtime@7.24.0)(react-native@0.74.3(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.24.0
       react: 18.2.0
       react-native: 0.74.3(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(@types/react@18.2.79)(react@18.2.0)
       recyclerlistview: 4.2.0(react-native@0.74.3(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       tslib: 2.4.0
+    optionalDependencies:
+      '@babel/runtime': 7.24.0
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -12269,6 +12303,16 @@ snapshots:
       esbuild: 0.17.19
       load-tsconfig: 0.2.5
 
+  burnt@0.12.2(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0)))(react-dom@18.2.0(react@18.2.0))(react-native@0.74.3(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      expo: 51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))
+      react: 18.2.0
+      react-native: 0.74.3(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(@types/react@18.2.79)(react@18.2.0)
+      sf-symbols-typescript: 1.0.0
+      sonner: 0.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - react-dom
+
   bytes@3.0.0: {}
 
   cac@6.7.14: {}
@@ -12935,6 +12979,12 @@ snapshots:
   expo-blur@13.0.2(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))):
     dependencies:
       expo: 51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))
+
+  expo-build-properties@0.12.5(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))):
+    dependencies:
+      ajv: 8.12.0
+      expo: 51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))
+      semver: 7.6.0
 
   expo-clipboard@6.0.3(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))):
     dependencies:
@@ -16159,6 +16209,8 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sf-symbols-typescript@1.0.0: {}
+
   shallow-clone@3.0.1:
     dependencies:
       kind-of: 6.0.3
@@ -16240,6 +16292,11 @@ snapshots:
       is-fullwidth-code-point: 2.0.0
 
   slugify@1.6.6: {}
+
+  sonner@0.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   source-map-js@1.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,9 +155,6 @@ importers:
       expo-blur:
         specifier: ~13.0.2
         version: 13.0.2(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0)))
-      expo-build-properties:
-        specifier: latest
-        version: 0.12.5(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0)))
       expo-clipboard:
         specifier: ~6.0.3
         version: 6.0.3(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0)))
@@ -4548,11 +4545,6 @@ packages:
 
   expo-blur@13.0.2:
     resolution: {integrity: sha512-t2p7BChO3Reykued++QJRMZ/og6J3aXtSQ+bU31YcBeXhZLkHwjWEhiPKPnJka7J2/yTs4+jOCNDY0kCZmcE3w==}
-    peerDependencies:
-      expo: '*'
-
-  expo-build-properties@0.12.5:
-    resolution: {integrity: sha512-donC1le0PYfLKCPKRMGQoixuWuwDWCngzXSoQXUPsgHTDHQUKr8aw+lcWkTwZcItgNovcnk784I0dyfYDcxybA==}
     peerDependencies:
       expo: '*'
 
@@ -12979,12 +12971,6 @@ snapshots:
   expo-blur@13.0.2(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))):
     dependencies:
       expo: 51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))
-
-  expo-build-properties@0.12.5(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))):
-    dependencies:
-      ajv: 8.12.0
-      expo: 51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))
-      semver: 7.6.0
 
   expo-clipboard@6.0.3(expo@51.0.24(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))):
     dependencies:


### PR DESCRIPTION
## Description:
Add Sonner screen using [Burnt](https://github.com/nandorojo/burnt) which wraps Sonner for web. For iOS, it wraps SPIndicator and AlertKit. For Android, it wraps React Native's ToastAndroid.

## Tested Platforms:

- [x] Web
- [ ] iOS (Burnt does not work with Expo Go so I'm unable to test it)
- [x] Android

## Affected Apps/Packages:
- Showcase app
- README.md

### Screenshots:
<img width="1462" alt="screenshot" src="https://github.com/user-attachments/assets/be1b2856-16e1-420d-8058-6330e8cefa5c">

#### Notes:
The Burnt package has not been updated in 6 months and is missing some of the newer features from Sonner. However, I have found use of Burnt alongside react-native-reusables in my project. Perhaps otherwise will find some use as well.
