### PR TITLE
fix: dynamic font scaling support for inputs and buttons

### DIFF
--- a/packages/reusables/src/components/ui/button.tsx
+++ b/packages/reusables/src/components/ui/button.tsx
@@ -1,8 +1,9 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
-import { Pressable } from 'react-native';
+import { Platform, Pressable } from 'react-native';
 import { cn } from '../../lib/utils';
 import { TextClassContext } from './text';
+import { useFontScale } from '../../lib/hooks';
 
 const buttonVariants = cva(
   'group flex items-center justify-center rounded-md web:ring-offset-background web:transition-colors web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2',
@@ -18,10 +19,10 @@ const buttonVariants = cva(
         link: 'web:underline-offset-4 web:hover:underline web:focus:underline ',
       },
       size: {
-        default: 'h-10 px-4 py-2 native:h-12 native:px-5 native:py-3',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8 native:h-14',
-        icon: 'h-10 w-10',
+        default: 'web:h-10 web:px-4 web:py-2',
+        sm: 'web:h-9 rounded-md web:px-3',
+        lg: 'web:h-11 rounded-md web:px-8',
+        icon: 'web:h-10 web:w-10',
       },
     },
     defaultVariants: {
@@ -61,7 +62,22 @@ type ButtonProps = React.ComponentPropsWithoutRef<typeof Pressable> &
   VariantProps<typeof buttonVariants>;
 
 const Button = React.forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>(
-  ({ className, variant, size, ...props }, ref) => {
+  ({ className, variant, size, style, children, ...props }, ref) => {
+    const { getScaledHeight } = useFontScale();
+    
+    const getSizeStyles = () => {
+      if (Platform.OS === 'web') return {};
+      
+      const sizes = {
+        default: { height: getScaledHeight(48, 16), paddingHorizontal: 20, paddingVertical: 12 },
+        sm: { height: getScaledHeight(36, 14), paddingHorizontal: 12 },
+        lg: { height: getScaledHeight(56, 18), paddingHorizontal: 32 },
+        icon: { height: getScaledHeight(40, 16), width: 40 },
+      };
+      
+      return sizes[size || 'default'];
+    };
+
     return (
       <TextClassContext.Provider
         value={buttonTextVariants({ variant, size, className: 'web:pointer-events-none' })}
@@ -71,10 +87,13 @@ const Button = React.forwardRef<React.ElementRef<typeof Pressable>, ButtonProps>
             props.disabled && 'opacity-50 web:pointer-events-none',
             buttonVariants({ variant, size, className })
           )}
+          style={[style, Platform.OS !== 'web' && getSizeStyles()]}
           ref={ref}
           role='button'
           {...props}
-        />
+        >
+          {children}
+        </Pressable>
       </TextClassContext.Provider>
     );
   }

--- a/packages/reusables/src/components/ui/input.tsx
+++ b/packages/reusables/src/components/ui/input.tsx
@@ -1,17 +1,29 @@
 import * as React from 'react';
-import { TextInput, type TextInputProps } from 'react-native';
+import { TextInput, type TextInputProps, Platform } from 'react-native';
 import { cn } from '../../lib/utils';
+import { useFontScale } from '../../lib/hooks';
 
 const Input = React.forwardRef<React.ElementRef<typeof TextInput>, TextInputProps>(
-  ({ className, placeholderClassName, ...props }, ref) => {
+  ({ className, placeholderClassName, style, ...props }, ref) => {
+    const { getScaledHeight } = useFontScale();
+    // Native-only values since web uses Tailwind classes
+    const baseHeight = 48; // h-12 = 48px
+    const baseFontSize = 18; // text-lg = 18px
+
     return (
       <TextInput
         ref={ref}
         className={cn(
-          'web:flex h-10 native:h-12 web:w-full rounded-md border border-input bg-background px-3 web:py-2 text-base lg:text-sm native:text-lg native:leading-[1.25] text-foreground placeholder:text-muted-foreground web:ring-offset-background file:border-0 file:bg-transparent file:font-medium web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2',
+          'web:flex web:h-10 web:w-full rounded-md border border-input bg-background px-3 web:py-2 text-base lg:text-sm native:text-lg native:leading-[1.25] text-foreground placeholder:text-muted-foreground web:ring-offset-background file:border-0 file:bg-transparent file:font-medium web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2',
           props.editable === false && 'opacity-50 web:cursor-not-allowed',
           className
         )}
+        style={[
+          style,
+          Platform.OS !== 'web' && {
+            height: getScaledHeight(baseHeight, baseFontSize),
+          },
+        ]}
         placeholderClassName={cn('text-muted-foreground', placeholderClassName)}
         {...props}
       />

--- a/packages/reusables/src/lib/hooks/index.ts
+++ b/packages/reusables/src/lib/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-font-scale';

--- a/packages/reusables/src/lib/hooks/use-font-scale.ts
+++ b/packages/reusables/src/lib/hooks/use-font-scale.ts
@@ -1,21 +1,28 @@
-import { PixelRatio } from 'react-native';
+import { useWindowDimensions } from 'react-native';
+import { useCallback } from 'react';
 
 const useFontScale = () => {
-  const fontScale = PixelRatio.getFontScale();
+  const { fontScale } = useWindowDimensions();
 
-  const getScaledSize = (size: number) => Math.round(size * fontScale);
+  const getScaledSize = useCallback(
+    (size: number) => Math.round(size * fontScale),
+    [fontScale]
+  );
 
-  const getScaledHeight = (height: number, fontSize: number) => {
-    const scaledFontSize = getScaledSize(fontSize);
-    const additionalHeight = Math.max(0, scaledFontSize - fontSize);
-    return height + additionalHeight;
-  };
+  const getScaledHeight = useCallback(
+    (height: number, fontSize: number) => {
+      const scaledFontSize = getScaledSize(fontSize);
+      const additionalHeight = Math.max(0, scaledFontSize - fontSize);
+      return height + additionalHeight;
+    },
+    [getScaledSize]
+  );
 
   return {
     fontScale,
     getScaledSize,
     getScaledHeight,
   };
-}
+};
 
 export { useFontScale };

--- a/packages/reusables/src/lib/hooks/use-font-scale.ts
+++ b/packages/reusables/src/lib/hooks/use-font-scale.ts
@@ -1,0 +1,21 @@
+import { PixelRatio } from 'react-native';
+
+const useFontScale = () => {
+  const fontScale = PixelRatio.getFontScale();
+
+  const getScaledSize = (size: number) => Math.round(size * fontScale);
+
+  const getScaledHeight = (height: number, fontSize: number) => {
+    const scaledFontSize = getScaledSize(fontSize);
+    const additionalHeight = Math.max(0, scaledFontSize - fontSize);
+    return height + additionalHeight;
+  };
+
+  return {
+    fontScale,
+    getScaledSize,
+    getScaledHeight,
+  };
+}
+
+export { useFontScale };


### PR DESCRIPTION
# Pull Request Template

## Description:
This PR introduces a new `useFontScale` hook to address text scaling issues in buttons and inputs on iOS and Android. Currently, when users increase their device's font size settings, text can get cut off in UI elements since they don't scale accordingly. 

The hook provides utilities to dynamically adjust component heights based on the system font scale, ensuring text remains visible and properly contained within UI elements. It uses React Native's `useWindowDimensions` to reactively update when system font settings change.

Fixes #219

## Tested Platforms:
- [x] Web
- [x] iOS
- [x] Android

## Affected Apps/Packages:
- ui

### Screenshots:
1. Input/button with default font scale
<img src="https://github.com/user-attachments/assets/7ce1fad6-3a2b-4c88-ab93-fc77f4354542" width="226" height="489" alt="Default font size input screenshot" />
<img src="https://github.com/user-attachments/assets/a26edd4f-e566-4f83-9a3e-ca577bf0a4d1" width="226" height="489" alt="Large font size input screenshot" />


2. Input/button with increased font scale
<img src="https://github.com/user-attachments/assets/77cd90ad-eab8-4618-9e3a-86cda31ba7b1" width="226" height="489" alt="Default font size screenshot" />
<img src="https://github.com/user-attachments/assets/2878efb6-d2e7-4af2-a2cb-5bf996f791ca" width="226" height="489" alt="Large font size screenshot" />



#### Notes:
- The hook provides three utilities:
  - `fontScale`: current system font scale factor
  - `getScaledSize`: scales any size value according to system font scale
  - `getScaledHeight`: calculates appropriate container height based on font size
- Components using this hook will automatically adjust their heights when system font size changes
- Implementation preserves existing web functionality while only applying scaling on native platforms
- The solution maintains consistent appearance across different device font size settings without requiring app restart

Example usage in components:
```typescript
const { getScaledHeight } = useFontScale();
const baseHeight = 48;
const baseFontSize = 16;

// Component height will now scale with system font size
const dynamicHeight = getScaledHeight(baseHeight, baseFontSize);