### PR TITLE
feat: added input OTP component with showcase, docs, CLI changes

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -32,6 +32,7 @@ If you do not add arguments, you will be prompted to select the `ui` components 
 - `dropdown-menu`
 - `hover-card`
 - `input`
+- `input-otp`
 - `label`
 - `menubar`
 - `navigation-menu`

--- a/apps/cli/src/items/components.ts
+++ b/apps/cli/src/items/components.ts
@@ -210,6 +210,21 @@ export const COMPONENTS = [
     ],
   },
   {
+    name: 'input-otp',
+    dependencies: [],
+    icons: [],
+    npmPackages: [],
+    paths: [
+      {
+        from: './node_modules/@rnr/reusables/src/components/ui/input-otp.tsx',
+        to: {
+          folder: 'ui',
+          file: 'input-otp.tsx',
+        },
+      },
+    ],
+  },
+  {
     name: 'label',
     dependencies: [],
     icons: [],

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -108,6 +108,10 @@ export default defineConfig({
               link: '/components/input/',
             },
             {
+              label: 'Input Otp',
+              link: '/components/input-otp/',
+            },
+            {
               label: 'Label',
               link: '/components/label/',
             },

--- a/apps/docs/src/content/docs/components/input-otp.mdx
+++ b/apps/docs/src/content/docs/components/input-otp.mdx
@@ -1,0 +1,76 @@
+---
+title: Input OTP
+description: Shows an input OTP component for verification codes.
+---
+
+{/* prettier-ignore-start */}
+{/* prettier-ignore-end */}
+
+import Code from '@/components/Code.astro';
+import { LinkButton } from '@/components/react/LinkButton';
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import importedCode from '@rnr/reusables/components/ui/input-otp?raw';
+
+<LinkButton target="_blank" href="https://rnr-showcase.vercel.app/input-otp">
+  Demo
+</LinkButton>
+
+<br />
+
+Shows an input otp component.
+
+## Installation
+
+<Tabs>
+  <TabItem label='CLI'> 
+    ```bash
+    npx @react-native-reusables/cli@latest add input-otp
+    ```
+  </TabItem>
+  <TabItem label='Manual'>
+**Copy/paste the following code to `~/components/ui/input-otp.tsx`**
+
+<Code code={importedCode} lang="tsx" title="~/components/ui/input-otp.tsx" />
+  </TabItem>
+</Tabs>
+
+
+## Usage
+
+```tsx
+import * as React from 'react';
+import { InputOTP } from '~/components/ui/input-otp';
+
+function Example() {
+  const [value, setValue] = React.useState('');
+
+  const onChangeText = (text: string) => {
+    setValue(text);
+  };
+
+  return (
+    <InputOTP
+      value={value}
+      onValueChange={onChangeText}
+      maxLength={6}
+      separator='-'
+      groupSize={3} // Try 1 for X-X-X-X-X-X or 2 for XX-XX-XX
+    />
+  );
+}
+```
+
+## Props
+
+### InputOTP
+Extends `ViewProps` from React Native.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | string | '' | The current value of the OTP input |
+| maxLength | number | 6 | Maximum number of characters |
+| onValueChange | (value: string) => void | - | Callback when value changes |
+| pattern | RegExp | /^[0-9]$/ | Pattern to validate each character |
+| separator | React.ReactNode | '-' | Separator between groups |
+| groupSize | number | 1 | Number of characters per group |
+| containerClassName | string | - | Additional classes for container |

--- a/apps/showcase/app/input-otp.tsx
+++ b/apps/showcase/app/input-otp.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { ScrollView, View } from 'react-native';
+import { InputOTP } from '~/components/ui/input-otp';
+import { Label } from '~/components/ui/label';
+import { Text } from '~/components/ui/text';
+import { cn } from '~/lib/utils';
+
+export default function InputOTPScreen() {
+  const [value1, setValue1] = React.useState('');
+  const [status, setStatus] = React.useState<'idle' | 'error' | 'success'>('idle');
+  const [message, setMessage] = React.useState<string | null>(null);
+
+  // Check OTP whenever value changes
+  React.useEffect(() => {
+    if (value1.length === 6) {
+      if (value1 === '123456') {
+        setStatus('success');
+        setMessage('OTP verified successfully!');
+      } else {
+        setStatus('error');
+        setMessage('Invalid OTP code. Please try again.');
+      }
+    } else {
+      setStatus('idle');
+      setMessage(null);
+    }
+  }, [value1]);
+
+  const handleValueChange = (text: string) => {
+    setValue1(text);
+  };
+
+  return (
+    <ScrollView contentContainerClassName='flex-1 justify-center items-center p-6'>
+      <View className='w-full max-w-sm space-y-4'>
+        {/* Single character grouping (1-2-3-4-5-6) */}
+        <View>
+          <Label
+            className={cn(
+              status === 'error' && 'text-destructive',
+              status === 'success' && 'text-emerald-500',
+              'pb-2 native:pb-1 pl-0.5'
+            )}
+            nativeID='otpLabel1'
+          >
+            Enter verification code
+          </Label>
+          <Text className='text-muted-foreground text-sm pb-4'>
+            Enter a 6-digit code. Try "123456" for success.
+          </Text>
+          
+          <InputOTP
+            value={value1}
+            onValueChange={handleValueChange}
+            maxLength={6}
+            separator="-"
+            groupSize={3}
+            aria-labelledby='otpLabel1'
+            aria-errormessage='otpMessage'
+            containerClassName={cn(
+              status === 'error' && 'animate-shake',
+              status === 'success' && 'animate-pulse',
+              'justify-start'
+            )}
+          />
+        </View>
+
+        {message && (
+          <View className='pt-2'>
+            <Text
+              className={cn(
+                'text-sm px-1 py-1.5',
+                status === 'error' && 'text-destructive',
+                status === 'success' && 'text-emerald-500'
+              )}
+              aria-invalid={status === 'error'}
+              id='otpMessage'
+            >
+              {message}
+            </Text>
+          </View>
+        )}
+
+        <View className='pt-4 space-y-2'>
+          <Text className='text-emerald-400 text-sm'>
+            Set OTP as 123456 for success message
+          </Text>
+          <Text className='text-red-400 text-sm'>
+            Any other 6-digit code will show error
+          </Text>
+        </View>
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/showcase/components/ui/input-otp.tsx
+++ b/apps/showcase/components/ui/input-otp.tsx
@@ -1,0 +1,4 @@
+import { Ui } from '@rnr/reusables';
+export const { InputOTP } = Ui;
+
+// See file: [[packages/reusables/src/components/ui/input.tsx]]

--- a/apps/showcase/lib/constants.ts
+++ b/apps/showcase/lib/constants.ts
@@ -25,6 +25,7 @@ export const COMPONENTS = [
   'form',
   'hover-card',
   'input',
+  'input-otp',
   'label',
   'material-top-tabs',
   'menubar',

--- a/packages/reusables/package.json
+++ b/packages/reusables/package.json
@@ -60,6 +60,7 @@
     "./components/ui/form": "./src/components/ui/form.tsx",
     "./components/ui/hover-card": "./src/components/ui/hover-card.tsx",
     "./components/ui/input": "./src/components/ui/input.tsx",
+    "./components/ui/input-otp": "./src/components/ui/input-otp.tsx",
     "./components/ui/label": "./src/components/ui/label.tsx",
     "./components/ui/menubar": "./src/components/ui/menubar.tsx",
     "./components/ui/navigation-menu": "./src/components/ui/navigation-menu.tsx",

--- a/packages/reusables/src/components/ui/index.ts
+++ b/packages/reusables/src/components/ui/index.ts
@@ -15,6 +15,7 @@ export * from './dropdown-menu';
 export * from './form';
 export * from './hover-card';
 export * from './input';
+export * from './input-otp';
 export * from './label';
 export * from './menubar';
 export * from './navigation-menu';

--- a/packages/reusables/src/components/ui/input-otp.tsx
+++ b/packages/reusables/src/components/ui/input-otp.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react';
+import { Pressable, Text, View, type ViewProps } from 'react-native';
+import Animated, { withRepeat, withSequence, withTiming, useAnimatedStyle } from 'react-native-reanimated';
+import { cn } from '../../lib/utils';
+import { Input } from './input';
+
+interface InputOTPProps extends ViewProps {
+  value?: string;
+  maxLength?: number;
+  onValueChange?: (value: string) => void;
+  pattern?: RegExp;
+  separator?: React.ReactNode;
+  containerClassName?: string;
+  onBlur?: () => void;
+  groupSize?: number; // Size of each group (e.g., 2 for XX-XX-XX format)
+}
+
+const InputOTP = React.forwardRef<React.ElementRef<typeof View>, InputOTPProps>(
+  (
+    {
+      className,
+      containerClassName,
+      value = '',
+      maxLength = 6,
+      pattern = /^[0-9]$/,
+      onValueChange,
+      separator = '-',
+      groupSize = 1,
+      onBlur,
+      ...props
+    },
+    ref
+  ) => {
+    const [focused, setFocused] = React.useState(false);
+    const inputRef = React.useRef<React.ElementRef<typeof Input>>(null);
+
+    const handlePress = () => {
+      inputRef.current?.focus();
+    };
+
+    const handleChangeText = (text: string) => {
+      if (text.length <= maxLength && text.split('').every((char) => pattern.test(char))) {
+        onValueChange?.(text);
+      }
+    };
+
+    const handleBlur = () => {
+      setFocused(false);
+      onBlur?.();
+    };
+
+    // Create groups of digits based on groupSize
+    const renderSlots = () => {
+      const slots = [];
+      for (let i = 0; i < maxLength; i++) {
+        // Add separator between groups
+        if (i > 0 && i % groupSize === 0 && separator) {
+          slots.push(
+            <Text key={`sep-${i}`} className='text-muted-foreground px-0.5'>
+              {separator}
+            </Text>
+          );
+        }
+        
+        slots.push(
+          <InputOTPSlot
+            key={i}
+            char={value[i]}
+            focused={focused && value.length === i}
+            filledCharacters={value.length}
+          />
+        );
+      }
+      return slots;
+    };
+
+    return (
+      <View
+        ref={ref}
+        className={cn('flex flex-row items-center justify-center', containerClassName)}
+        {...props}
+      >
+        <Input
+          ref={inputRef}
+          className='absolute opacity-0 w-0 h-0'
+          maxLength={maxLength}
+          keyboardType='number-pad'
+          value={value}
+          onChangeText={handleChangeText}
+          onFocus={() => setFocused(true)}
+          onBlur={handleBlur}
+        />
+        <Pressable onPress={handlePress}>
+          <View className='flex flex-row items-center'>{renderSlots()}</View>
+        </Pressable>
+      </View>
+    );
+  }
+);
+
+InputOTP.displayName = 'InputOTP';
+
+interface InputOTPSlotProps extends ViewProps {
+  char?: string;
+  focused?: boolean;
+  filledCharacters: number;
+}
+
+const InputOTPSlot = React.forwardRef<React.ElementRef<typeof View>, InputOTPSlotProps>(
+  ({ className, char, focused, filledCharacters, ...props }, ref) => {
+    const animatedStyle = useAnimatedStyle(() => {
+      if (!focused) return { opacity: 0 };
+      
+      return {
+        opacity: withRepeat(
+          withSequence(
+            withTiming(1, { duration: 500 }),
+            withTiming(0, { duration: 500 })
+          ),
+          -1,
+          true
+        ),
+      };
+    }, [focused]);
+
+    return (
+      <View
+        ref={ref}
+        className={cn(
+          'relative h-12 w-10 rounded-md border border-input bg-background mx-0.5',
+          focused && 'border-2 border-primary',
+          className
+        )}
+        {...props}
+      >
+        {char ? (
+          <Text className='absolute inset-0 text-center text-lg leading-[40px] text-foreground'>
+            {char}
+          </Text>
+        ) : (
+          <Animated.View
+            style={[animatedStyle]}
+            className='absolute top-3 bottom-3 left-1/2 w-0.5 -translate-x-1/2 bg-primary'
+          />
+        )}
+      </View>
+    );
+  }
+);
+
+InputOTPSlot.displayName = 'InputOTPSlot';
+
+export { InputOTP }; 


### PR DESCRIPTION
# Pull Request: Input OTP Component

## ✨ **Description:**
This PR introduces a **reusable OTP Input component** inspired by Shadcn-ui, providing enhanced flexibility and customization options. Key features include:

- **Customizable OTP Length:** Easily adjust the number of OTP fields.
- **Custom Separators:** Modify the separator between OTP characters.
- **Pattern Validation:** Define custom input patterns for OTP characters.
- **Group Size Configuration:** Split OTP fields into customizable groups.

In addition, a **showcase page** has been created to demonstrate the component’s capabilities (see the attached videos/screenshots below).

Documentation has been thoroughly updated to cover:
- Component usage and integration.
- CLI modifications to support the OTP component.

**Discussion related to this feature:**  
[Discussion #312](https://github.com/mrzachnugent/react-native-reusables/discussions/312)

---

## 🛠 **Changes:**

- **OTP Input Component** added with configurable features such as OTP length, separators, and input pattern.
- **Showcase Page** created for easy exploration of the component.
- **Documentation Updated** with usage examples and CLI instructions.
- **CLI Support** updated to include the new OTP component.

---

## ✅ **Tested Platforms:**

- [X] **Docs**
- [X] **Web**
- [X] **iOS**
- [ ] **Android**

---

## 📦 **Affected Apps/Packages:**

- [apps/app_x]
- [packages/package_y]

---

## 📸 **Screenshots/Media:**

**Video Demo:**  
![Video Demo](https://github.com/user-attachments/assets/374db00b-ea44-4881-be96-6ff17e087287)

**Docs Page:**  
![Docs Page](https://github.com/user-attachments/assets/ea8da3ce-c54d-4744-8c96-adc1d0ed3da5)

---

## 💬 **Notes:**
This is my first open-source contribution! If I’ve missed anything or if there’s any room for improvement, please let me know. I’ll address any feedback promptly.
