### PR TITLE
doc: Fix Label components usage code

### DIFF
--- a/apps/docs/src/content/docs/components/label.mdx
+++ b/apps/docs/src/content/docs/components/label.mdx
@@ -48,7 +48,7 @@ A user-friendly label linked to controls for improved accessibility.
 ### Usage
 
 ```tsx
-import { label } from '~/components/ui/label';
+import { Label } from '~/components/ui/label';
 
 function Example() {
   return <Label nativeID='name'>Name</Label>


### PR DESCRIPTION
## Description:

Saw this when was browsing the docs and thought I would fix it. The L in label should be capitalised in the import.

## Tested Platforms:

N/A

## Affected Apps/Packages:

N/A

### Screenshots:

<img width="694" alt="Screenshot 2025-01-20 at 17 09 06" src="https://github.com/user-attachments/assets/a0b91a31-8bcf-4931-9eab-02a9029bb055" />
