### PR TITLE
feat: improve init command and remove initializing existing project with cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ https://github.com/mrzachnugent/react-native-reusables/assets/63797719/ae7e074f-
 
 **Init**
 
-Quickly create a new project using the React Native Reusables CLI.
-
-> If a `package.json` is detected, the CLI will install all necessary dependencies and automatically configure your project for you.
+Quickly create a **new project** using the React Native Reusables CLI.
 
 ```bash
 npx @react-native-reusables/cli@latest init

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-reusables/cli",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Add react-native-reusables to your project.",
   "publishConfig": {
     "access": "public"

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -43,7 +43,7 @@ export const init = new Command()
         type: 'text',
         name: 'projectPath',
         message: `Enter the project name or relative path (e.g., 'my-app' or './apps/my-app'):`,
-        initial: './starter-base',
+        initial: './my-app',
       });
 
       const { packageManager } = await prompts({
@@ -89,11 +89,13 @@ export const init = new Command()
       ]);
 
       if (packageManager !== 'none') {
-        spinner.start(`Installing dependencies using ${packageManager}...`);
+        spinner.start(
+          `Installing dependencies using ${packageManager} (this may take a few minutes)...`
+        );
         await execa(packageManager, ['install'], {
           cwd: fullProjectPath,
         });
-        spinner.text = 'Running expo doctor to fix package version conflicts...';
+        spinner.text = 'Running expo doctor to ensure package compatibility...';
         await execa('npx', ['expo', 'install', '--fix'], {
           cwd: fullProjectPath,
         });
@@ -110,6 +112,13 @@ export const init = new Command()
         spinner.start('Initializing Git repository...');
         try {
           execSync('git init', { stdio: 'inherit', cwd: fullProjectPath });
+
+          execSync('git add -A', { stdio: 'inherit', cwd: fullProjectPath });
+          execSync('git commit -m "initialize project with @react-native-reusables/cli"', {
+            stdio: 'inherit',
+            cwd: fullProjectPath,
+          });
+
           spinner.succeed('Git repository initialized successfully.');
         } catch (error) {
           logger.error('Failed to initialize Git repository:', error);

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -42,7 +42,7 @@ export const init = new Command()
       const { projectPath } = await prompts({
         type: 'text',
         name: 'projectPath',
-        message: `What is the name of your project? (Include the path)`,
+        message: `Enter the project name or relative path (e.g., 'my-app' or './apps/my-app'):`,
         initial: './starter-base',
       });
 
@@ -89,11 +89,11 @@ export const init = new Command()
       ]);
 
       if (packageManager !== 'none') {
-        spinner.start('Installing dependencies...');
+        spinner.start(`Installing dependencies using ${packageManager}...`);
         await execa(packageManager, ['install'], {
           cwd: fullProjectPath,
         });
-        spinner.text = 'Verifying and updating any invalid package versions if needed...';
+        spinner.text = 'Running expo doctor to fix package version conflicts...';
         await execa('npx', ['expo', 'install', '--fix'], {
           cwd: fullProjectPath,
         });
@@ -110,9 +110,9 @@ export const init = new Command()
         spinner.start('Initializing Git repository...');
         try {
           execSync('git init', { stdio: 'inherit', cwd: fullProjectPath });
-          console.log('Git repository initialized successfully.');
+          spinner.succeed('Git repository initialized successfully.');
         } catch (error) {
-          console.error('Failed to initialize Git repository:', error);
+          logger.error('Failed to initialize Git repository:', error);
         }
       }
 
@@ -132,6 +132,9 @@ export const init = new Command()
         console.log('Install the dependencies manually using your package manager of choice.');
         console.log('Then run the dev script.');
       }
+      console.log('\nAdditional resources:');
+      console.log('- Documentation: https://rnr-docs.vercel.app');
+      console.log('- Report issues: https://github.com/mrzachnugent/react-native-reusables/issues');
       process.exit(0);
     } catch (error) {
       handleError(error);

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,164 +1,142 @@
 import { copyFolder } from '@/src/utils/copy-folder';
-import { getConfig } from '@/src/utils/get-config';
 import { handleError } from '@/src/utils/handle-error';
 import { logger } from '@/src/utils/logger';
-import { promptForConfig } from '@/src/utils/prompt-for-config';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
 import { Command } from 'commander';
 import { execa } from 'execa';
-import glob from 'fast-glob';
 import { existsSync, promises as fs } from 'fs';
-import ora, { Ora } from 'ora';
+import ora from 'ora';
 import path from 'path';
 import prompts from 'prompts';
 import { fileURLToPath } from 'url';
-import { z } from 'zod';
 
 const filePath = fileURLToPath(import.meta.url);
 const fileDir = path.dirname(filePath);
 
-const REQUIRED_DEPENDENCIES = [
-  'nativewind',
-  'expo-navigation-bar',
-  'tailwindcss',
-  'tailwindcss-animate',
-  'class-variance-authority',
-  'clsx',
-  'tailwind-merge',
-  'react-native-svg',
-  'react-native-reanimated',
-  'react-native-safe-area-context',
-  'lucide-react-native',
-  '@rn-primitives/portal',
-] as const;
-
-const TEMPLATE_FILES = [
-  'tailwind.config.js',
-  'nativewind-env.d.ts',
-  'global.css',
-  'babel.config.js',
-  'metro.config.js',
-  'lib/utils.ts',
-  'lib/useColorScheme.tsx',
-  'lib/constants.ts',
-  'lib/android-navigation-bar.ts',
-  'lib/icons/iconWithClassName.ts',
-] as const;
-
-const initOptionsSchema = z.object({
-  cwd: z.string(),
-  overwrite: z.boolean(),
-});
-
 export const init = new Command()
   .name('init')
-  .description('Initialize the required configuration for your React Native project')
-  .option(
-    '-c, --cwd <cwd>',
-    'the working directory. defaults to the current directory.',
-    process.cwd()
-  )
-  .option('-o, --overwrite', 'overwrite existing files', false)
-  .action(async (opts) => {
+  .description('Initialize a new React Native Reusables project')
+  .action(async () => {
     try {
-      const options = initOptionsSchema.parse(opts);
-      const cwd = path.resolve(options.cwd);
+      const cwd = process.cwd();
 
-      await validateProjectDirectory(cwd);
-      await checkGitStatus(cwd);
-      await initializeProject(cwd, options.overwrite);
+      if (existsSync(cwd) && existsSync(path.join(cwd, 'package.json'))) {
+        const { option } = await prompts({
+          type: 'select',
+          name: 'option',
+          message: 'Package.json found. How would you like to proceed?',
+          choices: [
+            { title: 'Initialize a new project', value: 'new-project' },
+            { title: 'Cancel', value: 'cancel' },
+          ],
+          initial: false,
+        });
+
+        if (option === 'cancel') {
+          logger.info('Installation cancelled.');
+          process.exit(0);
+        }
+      }
+
+      const { projectPath } = await prompts({
+        type: 'text',
+        name: 'projectPath',
+        message: `What is the name of your project? (Include the path)`,
+        initial: './starter-base',
+      });
+
+      const { packageManager } = await prompts({
+        type: 'select',
+        name: 'packageManager',
+        message: 'Which package manager would you like the CLI to use?',
+        choices: [
+          { title: 'npm', value: 'npm' },
+          { title: 'yarn', value: 'yarn' },
+          { title: 'pnpm', value: 'pnpm' },
+          { title: 'bun', value: 'bun' },
+          { title: 'None.', value: 'none' },
+        ],
+      });
+
+      const projectName: string = projectPath.split('/').pop();
+
+      const spinner = ora(`Initializing ${projectName}...`).start();
+
+      const fullProjectPath = path.join(cwd, projectPath);
+      if (!existsSync(fullProjectPath)) {
+        await fs.mkdir(fullProjectPath, { recursive: true });
+      }
+
+      const filesToIgnore = [];
+
+      if (packageManager !== 'pnpm') {
+        filesToIgnore.push('npmrc-template');
+      }
+
+      await copyFolder(path.join(fileDir, '../__generated/starter-base'), fullProjectPath, {
+        ignore: filesToIgnore,
+        renameTemplateFiles: true,
+      });
+
+      await Promise.all([
+        replaceAllInJsonFile(path.join(fullProjectPath, 'app.json'), 'starter-base', projectName),
+        replaceAllInJsonFile(
+          path.join(fullProjectPath, 'package.json'),
+          '@rnr/starter-base',
+          projectName
+        ),
+      ]);
+
+      if (packageManager !== 'none') {
+        spinner.start('Installing dependencies...');
+        await execa(packageManager, ['install'], {
+          cwd: fullProjectPath,
+        });
+        spinner.text = 'Verifying and updating any invalid package versions if needed...';
+        await execa('npx', ['expo', 'install', '--fix'], {
+          cwd: fullProjectPath,
+        });
+      }
+
+      spinner.stop();
+      const { gitInit } = await prompts({
+        type: 'confirm',
+        name: 'gitInit',
+        message: 'Would you like to initialize a Git repository?',
+      });
+
+      if (gitInit) {
+        spinner.start('Initializing Git repository...');
+        try {
+          execSync('git init', { stdio: 'inherit', cwd: fullProjectPath });
+          console.log('Git repository initialized successfully.');
+        } catch (error) {
+          console.error('Failed to initialize Git repository:', error);
+        }
+      }
+
+      spinner.succeed('New project initialized successfully!');
+      console.log(`\nTo get started, run the following commands:\n`);
+      console.log(chalk.cyan(`cd ${projectPath}`));
+      if (packageManager !== 'none') {
+        console.log(
+          chalk.cyan(
+            `${packageManager} ${
+              packageManager === 'npm' || packageManager === 'bun' ? 'run ' : ''
+            }dev`
+          )
+        );
+      }
+      if (packageManager === 'none') {
+        console.log('Install the dependencies manually using your package manager of choice.');
+        console.log('Then run the dev script.');
+      }
+      process.exit(0);
     } catch (error) {
       handleError(error);
     }
   });
-
-async function validateProjectDirectory(cwd: string) {
-  if (existsSync(cwd) && existsSync(path.join(cwd, 'package.json'))) {
-    const { option } = await prompts({
-      type: 'select',
-      name: 'option',
-      message:
-        'Package.json found. How would you like to proceed? (Selecting "Cancel" will exit the process)',
-      choices: [
-        { title: 'Automatically configure your existing project', value: 'existing-project' },
-        { title: 'Init new project', value: 'new-project' },
-        { title: 'Cancel', value: 'cancel' },
-      ],
-      initial: false,
-    });
-
-    if (option === 'cancel') {
-      logger.info('Installation cancelled.');
-      process.exit(0);
-    }
-
-    if (option === 'existing-project') {
-      return;
-    }
-  }
-
-  const { projectName } = await prompts({
-    type: 'text',
-    name: 'projectName',
-    message: `What is the name of your project?`,
-    initial: 'starter-base',
-  });
-
-  const { packageManager } = await prompts({
-    type: 'select',
-    name: 'packageManager',
-    message: 'Which package manager would you like to use?',
-    choices: [
-      { title: 'npm', value: 'npm' },
-      { title: 'yarn', value: 'yarn' },
-      { title: 'pnpm', value: 'pnpm' },
-      { title: 'bun', value: 'bun' },
-    ],
-  });
-
-  const spinner = ora(`Initializing ${projectName}...`).start();
-
-  const projectPath = path.join(cwd, projectName);
-  if (!existsSync(projectPath)) {
-    await fs.mkdir(projectPath, { recursive: true });
-  }
-
-  const filesToIgnore = [];
-
-  if (packageManager !== 'pnpm') {
-    filesToIgnore.push('npmrc-template');
-  }
-
-  await copyFolder(path.join(fileDir, '../__generated/starter-base'), projectPath, {
-    ignore: filesToIgnore,
-    renameTemplateFiles: true,
-  });
-
-  await Promise.all([
-    replaceAllInJsonFile(path.join(projectPath, 'app.json'), 'starter-base', projectName),
-    replaceAllInJsonFile(path.join(projectPath, 'package.json'), '@rnr/starter-base', projectName),
-  ]);
-
-  spinner.start('Installing dependencies...');
-  await execa(packageManager, ['install'], {
-    cwd: projectPath,
-  });
-  spinner.text = 'Verifying and updating any invalid package versions if needed...';
-  await execa('npx', ['expo', 'install', '--fix'], {
-    cwd: projectPath,
-  });
-
-  spinner.succeed('New project initialized successfully!');
-  console.log(`\nTo get started, run the following commands:\n`);
-  console.log(chalk.cyan(`cd ${projectName}`));
-  console.log(
-    chalk.cyan(
-      `${packageManager} ${packageManager === 'npm' || packageManager === 'bun' ? 'run ' : ''}dev`
-    )
-  );
-  process.exit(0);
-}
 
 async function replaceAllInJsonFile(path: string, searchValue: string, replaceValue: string) {
   try {
@@ -172,192 +150,6 @@ async function replaceAllInJsonFile(path: string, searchValue: string, replaceVa
 
     await fs.writeFile(path, replacedValue);
   } catch (error) {
-    handleError(error);
-  }
-}
-
-async function checkGitStatus(cwd: string) {
-  if (await shouldPromptGitWarning(cwd)) {
-    const { proceed } = await prompts({
-      type: 'confirm',
-      name: 'proceed',
-      message:
-        'The Git repository is dirty (uncommitted changes). It is recommended to commit your changes before proceeding. Do you want to continue?',
-      initial: false,
-    });
-
-    if (!proceed) {
-      logger.info('Installation cancelled.');
-      process.exit(0);
-    }
-  }
-}
-
-async function shouldPromptGitWarning(cwd: string): Promise<boolean> {
-  try {
-    execSync('git rev-parse --is-inside-work-tree', { cwd });
-    const status = execSync('git status --porcelain', { cwd }).toString();
-    return !!status;
-  } catch (error) {
-    return false;
-  }
-}
-
-async function initializeProject(cwd: string, overwrite: boolean) {
-  const spinner = ora(`Initializing project...`).start();
-
-  try {
-    let config = await getConfig(cwd);
-
-    if (!config) {
-      spinner.stop();
-      config = await promptForConfig(cwd);
-      spinner.start();
-    }
-
-    const templatesDir = path.join(fileDir, '../__generated/starter-base');
-
-    await installDependencies(cwd, spinner);
-    await updateTsConfig(cwd, config, spinner);
-
-    spinner.text = 'Adding config and utility files...';
-    for (const file of TEMPLATE_FILES) {
-      await copyTemplateFile(file, templatesDir, cwd, spinner, overwrite);
-    }
-
-    await updateLayoutFile(cwd, spinner);
-
-    spinner.succeed('Initialization completed successfully!');
-  } catch (error) {
-    spinner.fail('Initialization failed');
-    handleError(error);
-    process.exit(1);
-  }
-}
-
-async function installDependencies(cwd: string, spinner: Ora) {
-  try {
-    spinner.text = 'Installing dependencies...';
-    await execa('npx', ['expo', 'install', ...REQUIRED_DEPENDENCIES], {
-      cwd,
-      stdio: 'inherit',
-    });
-    spinner.text = 'Dependencies installed successfully';
-  } catch (error) {
-    spinner.fail('Failed to install dependencies');
-    handleError(error);
-    process.exit(1);
-  }
-}
-
-const NON_PATH_ALIAS_BASES = ['', '.', '/'];
-
-async function updateTsConfig(cwd: string, config: any, spinner: Ora) {
-  try {
-    const tsconfigPath = path.join(cwd, 'tsconfig.json');
-    const tsconfig = existsSync(tsconfigPath)
-      ? JSON.parse(await fs.readFile(tsconfigPath, 'utf8'))
-      : {};
-
-    const componentBase = config.aliases.components.split('/')[0];
-    const libBase = config.aliases.lib.split('/')[0];
-
-    if (NON_PATH_ALIAS_BASES.includes(componentBase) || NON_PATH_ALIAS_BASES.includes(libBase)) {
-      return;
-    }
-
-    const tsconfigPaths = tsconfig.compilerOptions?.paths ?? {};
-
-    if (
-      tsconfigPaths[`${componentBase}/*`]?.[0] === '*' &&
-      tsconfigPaths[`${libBase}/*`]?.[0] === '*'
-    ) {
-      spinner.succeed('Path aliases already configured');
-      return;
-    }
-
-    spinner.text = 'Updating path aliases...';
-
-    tsconfig.compilerOptions = {
-      ...tsconfig.compilerOptions,
-      baseUrl: '.',
-      paths: {
-        [`${componentBase}/*`]: ['*'],
-        [`${libBase}/*`]: ['*'],
-        ...tsconfig.compilerOptions?.paths,
-      },
-    };
-
-    await fs.writeFile(tsconfigPath, JSON.stringify(tsconfig, null, 2));
-  } catch (error) {
-    spinner.fail('Failed to update tsconfig.json');
-    handleError(error);
-  }
-}
-
-async function copyTemplateFile(
-  file: string,
-  templatesDir: string,
-  targetDir: string,
-  spinner: Ora,
-  overwriteFlag: boolean
-) {
-  const targetPath = path.join(targetDir, file);
-  spinner.stop();
-
-  if (existsSync(targetPath)) {
-    if (!overwriteFlag) {
-      logger.info(
-        `File already exists: ${chalk.bgCyan(
-          file
-        )} was skipped. To overwrite, run with the ${chalk.green('--overwrite')} flag.`
-      );
-      return;
-    }
-
-    const { overwrite } = await prompts({
-      type: 'confirm',
-      name: 'overwrite',
-      message: `File already exists: ${chalk.yellow(file)}. Would you like to overwrite?`,
-      initial: false,
-    });
-
-    if (!overwrite) {
-      logger.info(`Skipped`);
-      return;
-    }
-  }
-
-  spinner.start(`Installing ${file}...`);
-  await fs.mkdir(path.dirname(targetPath), { recursive: true });
-  await fs.copyFile(path.join(templatesDir, file), targetPath);
-}
-
-async function updateLayoutFile(cwd: string, spinner: Ora) {
-  try {
-    const layoutFiles = await glob(
-      ['app/_layout.{ts,tsx,js,jsx}', '(app)/_layout.{ts,tsx,js,jsx}'],
-      {
-        cwd,
-        ignore: ['node_modules/**'],
-      }
-    );
-
-    if (!layoutFiles.length) {
-      spinner.warn('Could not find the root _layout file');
-      return;
-    }
-
-    const layoutPath = path.join(cwd, layoutFiles[0]);
-    const content = await fs.readFile(layoutPath, 'utf8');
-
-    if (!content.includes('import "../global.css"')) {
-      spinner.text = 'Updating layout file...';
-      await fs.writeFile(layoutPath, `import "../global.css";\n${content}`);
-      spinner.succeed(`Updated ${layoutFiles[0]} with global CSS import`);
-    }
-  } catch (error) {
-    spinner.fail('Failed to update layout file');
     handleError(error);
   }
 }

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -59,7 +59,7 @@ export const init = new Command()
         ],
       });
 
-      const projectName: string = projectPath.split('/').pop();
+      const projectName = path.basename(projectPath);
 
       const spinner = ora(`Initializing ${projectName}...`).start();
 

--- a/apps/docs/src/content/docs/components/dropdown-menu.mdx
+++ b/apps/docs/src/content/docs/components/dropdown-menu.mdx
@@ -155,7 +155,6 @@ Extends [`View`](https://reactnative.dev/docs/view#props) props
 | :----------: | :----------------------: | :----------: |
 | onOpenChange| (value: boolean) => void |                         |
 |   asChild    |         boolean          |       _(optional)_      |
-|  relativeTo  | 'longPress' \| 'trigger' | Native Only _(optional)_ |
 
 ### DropdownMenuTrigger
 

--- a/apps/docs/src/content/docs/getting-started/initial-setup.mdx
+++ b/apps/docs/src/content/docs/getting-started/initial-setup.mdx
@@ -16,10 +16,6 @@ import importedTwNativeCondig from '@/code-samples/tw-native-config.js?raw';
 
     Quickly create a **new project** using the React Native Reusables CLI.
 
-    <Aside type="note" title="For existing projects">
-      If a `package.json` is detected, the CLI will install all [necessary dependencies](#features) and automatically configure your project for you.
-    </Aside>
-
     <img
       src='https://github.com/mrzachnugent/react-native-reusables/assets/63797719/42c94108-38a7-498b-9c70-18640420f1bc'
       alt='starter-base-template'
@@ -44,9 +40,17 @@ import importedTwNativeCondig from '@/code-samples/tw-native-config.js?raw';
       ```
     </Aside>
 
-    ### Features
+    ### Starter-base template
 
-      <Aside type="note" title="React Native Reusables">
+      <Aside type="note" title="Features">
+        - Components
+            - [Avatar](/components/avatar)
+            - [Button](/components/button)
+            - [Card](/components/card)
+            - [Progress](/components/progress)
+            - [Text](/components/text)
+            - [Tooltip](/components/tooltip)
+            - Theme Toggle
         - Dependencies
           - [NativeWind](https://www.nativewind.dev/)
           - [Expo Navigation Bar](https://docs.expo.dev/versions/latest/sdk/navigation-bar/)
@@ -107,13 +111,6 @@ import importedTwNativeCondig from '@/code-samples/tw-native-config.js?raw';
         - tailwind.config.js
         - tsconfig.json
       </FileTree>
-
-    ### Options
-
-    | Option             | Description              | Default           |
-    | :----------------- | :----------------------- | :---------------- |
-    | `-c, --cwd <path>` | The working directory    | Current directory |
-    | `-o, --overwrite`  | Overwrite existing files _(for existing projects)_ | `false`           |
 
  </TabItem>
 

--- a/packages/templates/starter-base/package.json
+++ b/packages/templates/starter-base/package.json
@@ -3,7 +3,7 @@
   "main": "index.js",
   "version": "1.0.0",
   "scripts": {
-    "dev": "expo start -c --ios",
+    "dev": "expo start -c",
     "dev:web": "expo start -c --web",
     "dev:android": "expo start -c --android",
     "android": "expo start -c --android",


### PR DESCRIPTION
# Description

This removes the ability to init an existing project with the CLI and improves starting a new project.

## Improvements
- Path to new project is clearer
- Option to prevent using a package manager
- Option to initialize git


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes v0.3.6

- **Documentation**
  - Updated README.md with minor text formatting.
  - Revised initial setup documentation, removing the "For existing projects" section and introducing details about the new starter-base template.

- **CLI Improvements**
  - Simplified project initialization process with more direct user prompts.
  - Removed specific command-line options for a streamlined experience.

- **Development**
  - Updated CLI package version to 0.3.6.
  - Modified development script to remove platform-specific default.

- **Component Updates**
  - Simplified `DropdownMenu` props by removing the `relativeTo` prop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->