### PR TITLE
fix: form select set wrong `label` value on `value` prop

### DIFF
--- a/packages/reusables/src/components/ui/form.tsx
+++ b/packages/reusables/src/components/ui/form.tsx
@@ -526,7 +526,7 @@ const FormSelect = React.forwardRef<
             : `${formDescriptionNativeID} ${formMessageNativeID}`
         }
         aria-invalid={!!error}
-        value={value ? { label: value?.label ?? '', value: value?.label ?? '' } : undefined}
+        value={value ? { label: value?.label ?? '', value: value?.value ?? '' } : undefined}
         onValueChange={onChange}
         {...props}
       />


### PR DESCRIPTION
# Pull Request

<!--

# Important Note:

Please create a [discussion](https://github.com/mrzachnugent/react-native-reusables/discussions/categories/ideas) for any new feature proposals **before** submitting a pull request. This helps ensure alignment with project goals and gather community feedback.

-->

## Description:

<!-- Provide a brief description of the changes introduced by this pull request. -->

Fixed FormSelect component setting `label` value on `value` prop.

## Tested Platforms:

<!-- Check the platforms that you have tested this PR on. -->

- [ ] Docs
- [ ] Web
- [ ] iOS
- [ ] Android


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the way selection values are processed in forms, ensuring that the displayed value accurately reflects the actual input without duplicating labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->