### PR TITLE
Fix package manager search order

### DIFF
--- a/apps/cli/src/services/package-manager.ts
+++ b/apps/cli/src/services/package-manager.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { detect } from "package-manager-detector"
 
-const PACKAGE_MANAGERS = ["npm", "bun", "pnpm", "yarn", "yarn@berry"] as const
+const PACKAGE_MANAGERS = ["npm", "bun", "pnpm", "yarn@berry", "yarn"] as const
 
 const BINARY_RUNNERS = {
   npm: ["npx", "--yes"],


### PR DESCRIPTION
# Pull Request Template

<!--

⚠️ **Important**

**If you want to propose a new feature:**

1.  Make sure to read the [project scope](https://github.com/founded-labs/react-native-reusables/discussions/229) to confirm your proposal fits within the vision and purpose of `react-native-reusables`.
2. Before taking any action, please open a [new discussion](https://github.com/founded-labs/react-native-reusables/discussions). This allows us to collaborate, gather feedback, and ensure alignment with the project's goals.

-->

## Description:

<!-- Provide a brief description of the changes introduced by this pull request. -->

Follow up to #444. I accidentally added `yarn@berry` to the end of the package managers list. This causes an issue because we use a `startsWith` check on the package manager agent/name, and `'yarn@berry'.startsWith('yarn') === true`.

Simply putting `yarn@berry` first in the list resolves this issue.

## Tested Platforms:

<!-- Check the platforms that you have tested this PR on. -->

- [ ] Web
- [ ] iOS
- [ ] Android

## Affected Apps/Packages:

<!-- Specify which apps or packages are affected by this pull request. -->

- [ ] apps/docs
- [ ] apps/showcase
- [x] apps/cli
- [ ] packages/registry

### Screenshots:

<!-- If applicable, add screenshots to showcase the changes visually. -->

#### Notes:

<!-- Add any additional notes or context that reviewers should be aware of. -->

I had missed this because I had forgotten that I applied an _additional_ patch locally while waiting for the related `shadcn` patch to merge. I have confirmed that this change _actually_ fixes the issue when applied locally. Sorry about that!
