### PR TITLE
Fix the minor typo in project-manifest.ts

### DIFF
--- a/apps/cli/src/project-manifest.ts
+++ b/apps/cli/src/project-manifest.ts
@@ -68,7 +68,7 @@ const FILE_CHECKS: Array<FileCheck> = [
   {
     name: "Root Layout",
     fileNames: ["app/_layout.tsx", "src/app/_layout.tsx"],
-    docs: "hhttps://reactnativereusables.com/docs/installation/manual#add-the-portal-host-to-your-root-layout", //
+    docs: "https://reactnativereusables.com/docs/installation/manual#add-the-portal-host-to-your-root-layout", //
     includes: [
       {
         content: [".css"],


### PR DESCRIPTION
## Description:

Fixes a very minor url typo in the doctor cli output.

## Tested Platforms:

- [X] Web
- [X] iOS
- [X] Android

## Affected Apps/Packages:

- [ ] apps/docs
- [ ] apps/showcase
- [X] apps/cli
- [ ] packages/registry

### Screenshots:

<!-- If applicable, add screenshots to showcase the changes visually. -->

#### Notes:

<!-- Add any additional notes or context that reviewers should be aware of. -->
