### PR TITLE
Update input.tsx to support i18n

### DIFF
--- a/packages/registry/src/new-york/components/ui/input.tsx
+++ b/packages/registry/src/new-york/components/ui/input.tsx
@@ -1,32 +1,44 @@
-import { cn } from '@/registry/new-york/lib/utils';
+import { cn } from '@/lib/utils';
+import React from 'react';
 import { Platform, TextInput, type TextInputProps } from 'react-native';
 
-function Input({
-  className,
-  ...props
-}: TextInputProps & React.RefAttributes<TextInput>) {
-  return (
-    <TextInput
-      className={cn(
-        'dark:bg-input/30 border-input bg-background text-foreground flex h-10 w-full min-w-0 flex-row items-center rounded-md border px-3 py-1 text-base leading-5 shadow-sm shadow-black/5 sm:h-9',
-        props.editable === false &&
-          cn(
-            'opacity-50',
-            Platform.select({ web: 'disabled:pointer-events-none disabled:cursor-not-allowed' })
-          ),
-        Platform.select({
-          web: cn(
-            'placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] md:text-sm',
-            'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-            'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
-          ),
-          native: 'placeholder:text-muted-foreground/50',
-        }),
-        className
-      )}
-      {...props}
-    />
-  );
+interface InputProps extends TextInputProps {
+  isRTL?: boolean;
 }
+
+const Input = React.forwardRef<TextInput, InputProps>(
+  ({ className, isRTL = false, ...props }, ref) => {
+    const rtlClasses = isRTL ? 'text-right' : 'text-left';
+    const rtlPlaceholder = isRTL ? 'placeholder:text-right' : 'placeholder:text-left';
+
+    return (
+      <TextInput
+        ref={ref} 
+        className={cn(
+          'dark:bg-input/30 border-input bg-background text-foreground flex h-10 w-full min-w-0 flex-row items-center rounded-md border px-3 py-1 text-base leading-5 shadow-sm shadow-black/5 sm:h-9',
+          rtlClasses,
+          props.editable === false &&
+            cn(
+              'opacity-50',
+              Platform.select({ web: 'disabled:pointer-events-none disabled:cursor-not-allowed' })
+            ),
+          Platform.select({
+            web: cn(
+              'selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] md:text-sm',
+              'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+              'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+              rtlPlaceholder
+            ),
+            native: cn('placeholder:text-muted-foreground/50', rtlPlaceholder),
+          }),
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Input.displayName = 'Input';
 
 export { Input };


### PR DESCRIPTION
Added i18n support for the input

# Pull Request Template

<!--

⚠️ **Important**

**If you want to propose a new feature:**

1.  Make sure to read the [project scope](https://github.com/founded-labs/react-native-reusables/discussions/229) to confirm your proposal fits within the vision and purpose of `react-native-reusables`.
2. Before taking any action, please open a [new discussion](https://github.com/founded-labs/react-native-reusables/discussions). This allows us to collaborate, gather feedback, and ensure alignment with the project's goals.

-->

## Description:

<!-- Provide a brief description of the changes introduced by this pull request. -->

Added i18n support for input component<!-- Add the issue number that this PR fixes, if applicable. -->

## Tested Platforms:

<!-- Check the platforms that you have tested this PR on. -->

- [ * ] Web
- [ * ] iOS
- [ * ] Android

## Affected Apps/Packages:

<!-- Specify which apps or packages are affected by this pull request. -->

- [ ] apps/docs " I don't think so, probably just the component's doc if there is "
- [ * ] apps/showcase " Probably if you wanna showcase i18n support "
- [ ] apps/cli  " I don't think so, unless you wanna change the template "
- [ * ] packages/registry " because the component now supports i18n "

### Screenshots:

<!-- If applicable, add screenshots to showcase the changes visually. -->
<img width="245" height="34" alt="Screenshot 2025-11-01 at 7 59 32 AM" src="https://github.com/user-attachments/assets/012530e0-a4dd-4cc6-92b1-c1ef95ab4166" />
<img width="249" height="37" alt="Screenshot 2025-11-01 at 8 00 17 AM" src="https://github.com/user-attachments/assets/dcaa1bac-c8df-4d1f-a953-d400cbac0431" />


#### Notes:

<!-- Add any additional notes or context that reviewers should be aware of. -->
I'll make a pull request for all other components to support i18n if you would like it, I would really like to collaborate with making this package better