### PR TITLE
fix(cli): detect uniwind dtsFile from metro config

### DIFF
--- a/apps/cli/src/services/commands/add.ts
+++ b/apps/cli/src/services/commands/add.ts
@@ -4,6 +4,7 @@ import { Doctor } from "@cli/services/commands/doctor.js"
 import { runCommand } from "@cli/utils/run-command.js"
 import { Prompt } from "@effect/cli"
 import { Effect, Layer } from "effect"
+import logSymbols from "log-symbols"
 import { PackageManager } from "../package-manager.js"
 import { ProjectConfig } from "../project-config.js"
 
@@ -52,6 +53,7 @@ class Add extends Effect.Service<Add>()("Add", {
           yield* Effect.logDebug(`Selected components: ${components.join(", ")}`)
 
           const stylingLibrary = yield* projectConfig.getStylingLibrary()
+          console.log(`${logSymbols.info} Detected: ${stylingLibrary === "uniwind" ? "Uniwind" : "Nativewind"}`)
 
           const baseUrl =
             process.env.INTERNAL_ENV === "development"


### PR DESCRIPTION
Fixes #493

## Description:

Fixes CLI detection of Uniwind when `dtsFile` is configured at a custom path in `metro.config.js`.

Previously, the CLI only checked for `uniwind-types.d.ts` in the project root. Uniwind allows specifying a custom path via the `dtsFile` option in `withUniwindConfig()`, which caused detection to fail for projects using non-root paths.

### Changes:
- Added `getUniwindDtsPath()` function that parses `metro.config.js`/`metro.config.ts` to extract the `dtsFile` path from `withUniwindConfig`
- Updated `getStylingLibrary()` to use dynamic path detection
- Added `StylingLibrary` type for better type safety
- Updated `required-files-checker.ts` to use the dynamic uniwind types path
- Added detection log message showing "Detected: Nativewind" or "Detected: Uniwind" before registry check

### Example:

For a metro config like:
```js
module.exports = withUniwindConfig(config, {
  cssEntryFile: "./src/global.css",
  dtsFile: "./src/uniwind-types.d.ts",
});
```
The CLI now correctly detects Uniwind instead of falling back to Nativewind.

## Tested Platforms:

- [ ] Web
- [ ] iOS
- [ ] Android

## Affected Apps/Packages:

- [ ] apps/docs
- [ ] apps/showcase
- [x] apps/cli
- [ ] packages/registry

### Screenshots:

<img width="220" height="52" alt="Screenshot 2025-12-13 at 11 15 01 PM" src="https://github.com/user-attachments/assets/03a68bd1-f7a6-42c5-9066-0386254e9b47" />
