### PR TITLE
fix(docs): add missing `SelectGroup` and `SelectLabel` imports

### DIFF
--- a/apps/docs/content/docs/components/select.mdx
+++ b/apps/docs/content/docs/components/select.mdx
@@ -175,11 +175,12 @@ import { StylingLibraryTabs, StylingLibraryTabsNativewindContent, StylingLibrary
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-
 ```
 
 ```tsx


### PR DESCRIPTION
## Description:

This PR updates the `Select` component documentation to include missing exports in the "Usage" section.

Specifically, `SelectGroup` and `SelectLabel` were used in the example code block but were missing from the import statement. This change ensures the provided example code is complete and copy-paste ready.

## Affected Apps/Packages:

- [x] apps/docs
- [ ] apps/showcase
- [ ] apps/cli
- [ ] packages/registry
