### PR TITLE
fix: minor import error of uniwind/lib components

### DIFF
--- a/packages/registry/src/uniwind/lib/index.ts
+++ b/packages/registry/src/uniwind/lib/index.ts
@@ -1,1 +1,1 @@
-export * from '@/registry/uniwind/registry/nativewind/lib/utils';
+export * from '@/registry/uniwind/lib/utils';


### PR DESCRIPTION
## Description:

Fixes a minor import error of uniwind/lib components

## Tested Platforms:

- [x] Web
- [x] iOS
- [x] Android

## Affected Apps/Packages:

- [ ] apps/docs
- [ ] apps/showcase
- [ ] apps/cli
- [x] packages/registry

### Screenshots:

#### Notes:
